### PR TITLE
Fix my first tutorial

### DIFF
--- a/manual/en/my_first_web_api.md
+++ b/manual/en/my_first_web_api.md
@@ -11,7 +11,7 @@ Let's use the resource we made in [My First Resource](my_first_resource.html) as
 Start the built in web server for the API.
 
 ```
-$ php -S 0.0.0.0:8081 {$PROJECT_PATH}/apps/Demo.Sandbox/bootstrap/contexts/api.php
+$ bin/bear.server --port=8081 --context=api apps/Demo.Sandbox
 ```
 
 We can then access it through a REST client ([for FireFox](https://addons.mozilla.org/ja/firefox/addon/restclient/#id=9780), or [for Chrome](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo))

--- a/manual/en/my_first_web_page.md
+++ b/manual/en/my_first_web_page.md
@@ -59,8 +59,7 @@ When the get request is called it does nothing but return itself.
 Let's check this resource from the command line.
 
 ```
-$ cd {$PROJECT_PATH}/apps/Demo.Sandbox/bootstrap/contexts/
-$ php api.php get page://self/first/greeting
+$ php apps/Demo.Sandbox/bootstrap/contexts/api.php get page://self/first/greeting
 
 200 OK
 content-type: ["application\/hal+json; charset=UTF-8"]
@@ -107,7 +106,7 @@ This is a HTML page and can also be checked via the command line.
 Lets check.
 
 ```
-$ php dev.php get /first/greeting
+$ php apps/Demo.Sandbox/bootstrap/contexts/dev.php get /first/greeting
 ```
 
 ```html
@@ -132,7 +131,7 @@ HTML all checked!
 ## Checking the Page HTML in a Web Browser 
 
 ```
-$ php -S localhost:8088 dev.php
+$ bin/bear.server --port=8088 --context=dev apps/Demo.Sandbox
 ```
 
 Browse http://localhost:8088/first/greeting 

--- a/manual/ja/my_first_resource.md
+++ b/manual/ja/my_first_resource.md
@@ -45,8 +45,8 @@ Hello, BEAR.
 
 Sandboxアプリケーションに実装します。URIとPHPのクラス、ファイル位置はこのように対応します。
 
-| URI | Class | File |
-|-----|--------|-----|
+| URI | クラス | ファイル |
+|-----|--- ----|----------|
 | app://self/first/greeting | Demo\Sandbox\Resource\App\First\Greeting | apps/Demo.Sandbox/src/Sandbox/Resource/App/First/Greeting.php |
 
 リクエストインターフェイス（メソッド）を実装します。

--- a/manual/ja/my_first_web_api.md
+++ b/manual/ja/my_first_web_api.md
@@ -11,10 +11,10 @@ category: My First - Tutorial
 API用のビルトインWebサーバーを起動します。
 
 ```
-$ php -S 0.0.0.0:8081 {$PROJECT_PATH}/apps/Demo.Sandbox/bootstrap/contexts/api.php
+$ bin/bear.server --port=8081 --context=api apps/Demo.Sandbox
 ```
 
-ブラウザのアドオンのRESTクライアント（FireFox用](https://addons.mozilla.org/ja/firefox/addon/restclient/#id=9780) や [Chrome用](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo)）等でアクセスします。
+ブラウザのアドオンのRESTクライアント（[FireFox用](https://addons.mozilla.org/ja/firefox/addon/restclient/#id=9780) や [Chrome用](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo)）等でアクセスします。
 
 ```
 GET http://localhost:8081/app/first/greeting?name=BEAR

--- a/manual/ja/my_first_web_page.md
+++ b/manual/ja/my_first_web_page.md
@@ -59,8 +59,7 @@ GETリクエストは呼ばれると何もしないで自身を返していま�
 このリソースをコマンドラインで確認してみましょう。
 
 ```
-$ cd {$PROJECT_PATH}/apps/Demo.Sandbox/bootstrap/contexts/
-$ php api.php get page://self/first/greeting
+$ php apps/Demo.Sandbox/bootstrap/contexts/api.php get page://self/first/greeting
 
 200 OK
 content-type: ["application\/hal+json; charset=UTF-8"]
@@ -107,7 +106,7 @@ greeting Hello.,
 では確認してみましょう。
 
 ```
-$ php dev.php get /first/greeting
+$ php apps/Demo.Sandbox/bootstrap/contexts/dev.php get /first/greeting
 ```
 
 ```html
@@ -135,7 +134,7 @@ HTMLが確認できました。
 ## WebブラウザでページHTMLを確認します
 
 ```
-$ php -S localhost:8088 dev.php
+$ bin/bear.server --port=8088 --context=dev apps/Demo.Sandbox
 ```
 
 http://localhost:8088/first/greeting にアクセスします。


### PR DESCRIPTION
- ビルトインWebサーバの起動をbear.serverコマンドに変更
- CLIでの実行時のカレントディレクトリを {$PACKAGE_DIR} を前提に。コマンドをコピペして実行できるように {$PACKAGE_DIR} という表記は省略
- 翻訳漏れ
- typo修正
