### PR TITLE
Fix install.md

### DIFF
--- a/manual/en/install.md
+++ b/manual/en/install.md
@@ -26,7 +26,7 @@ $ composer create-project bear/package {$PACKAGE_DIR}
 
 ```
 $ cd {$PACKAGE_DIR}
-$ php bin/env.php
+$ bin/bear.env
 ```
 
 BEAR.Sunday application can be accessed via the web or CLI.


### PR DESCRIPTION
Hi! I found `bin/env.php` does not exist when I tried to install BEAR.Sunday by following this manual http://bearsunday.github.io/manual/en/install.html.
