### PR TITLE
[ja] クイックスタート校正

### DIFF
--- a/manuals/1.0/ja/quick-start.md
+++ b/manuals/1.0/ja/quick-start.md
@@ -55,7 +55,7 @@ Content-Type: application/hal+json
 }
 {% endhighlight %}
 
-次にPHPのビルトインサーバを起動してみましょう。
+次にPHPのビルトインウェブサーバを起動してみましょう。
 
 {% highlight bash %}
 php -S 127.0.0.1:8080 var/www/index.php

--- a/manuals/1.0/ja/quick-start.md
+++ b/manuals/1.0/ja/quick-start.md
@@ -55,7 +55,7 @@ Content-Type: application/hal+json
 }
 {% endhighlight %}
 
-次にPHPサーバを起動してみましょう。
+次にPHPのビルトインサーバを起動してみましょう。
 
 {% highlight bash %}
 php -S 127.0.0.1:8080 var/www/index.php

--- a/manuals/1.0/ja/quick-start.md
+++ b/manuals/1.0/ja/quick-start.md
@@ -60,3 +60,5 @@ Content-Type: application/hal+json
 {% highlight bash %}
 php -S 127.0.0.1:8080 var/www/index.php
 {% endhighlight %}
+
+ブラウザで http://127.0.0.1:8080/hello にアクセスすると、`{"greeting": "Hello BEAR.Sunday"}` と表示されます。


### PR DESCRIPTION
コミットした修正の他に 
> `Hello`と`$_GET['name']`文字列を連結して

https://github.com/bearsunday/bearsunday.github.io/blame/master/manuals/1.0/ja/quick-start.md#L38
の部分が気になっています。
「`Hello`と`$name`を」と書いて`$name`が`$_GET['name']`であることを説明したほうがわかりやすいのではないかと思いますが、いかがでしょうか？