### PR TITLE
Fix tutorial2 migration

### DIFF
--- a/manuals/1.0/en/tutorial2.md
+++ b/manuals/1.0/en/tutorial2.md
@@ -38,12 +38,12 @@ composer require --dev robmorgan/phinx
 Describe the DB connection information in the `.env.dist` file in the project root folder.
 
 ```
-TKT_DB_HOST=127.0.0.1
+TKT_DB_HOST=127.0.0.1:3306
 TKT_DB_NAME=ticket
 TKT_DB_USER=root
 TKT_DB_PASS=''
 TKT_DB_SLAVE=''
-TKT_DB_DSN=mysql:host=${TKT_DB_HOST};dbname=${TKT_DB_NAME}
+TKT_DB_DSN=mysql:host=${TKT_DB_HOST}
 ```
 
 The `.env.dist` file should look like this, and the actual connection information should be written in `.env`. ^1]
@@ -139,6 +139,17 @@ final class Ticket extends AbstractMigration
     }
 }
 ```
+
+In addition, edit `.env.dist` like the following.
+
+```diff
+ TKT_DB_USER=root
+ TKT_DB_PASS=
+ TKT_DB_SLAVE=
+-TKT_DB_DSN=mysql:host=${TKT_DB_HOST}
++TKT_DB_DSN=mysql:host=${TKT_DB_HOST};dbname=${TKT_DB_NAME}
+```
+
 
 Now that the preparation is complete, run the setup command to create the table.
 

--- a/manuals/1.0/ja/tutorial2.md
+++ b/manuals/1.0/ja/tutorial2.md
@@ -36,12 +36,12 @@ composer require --dev robmorgan/phinx
 プロジェクトルートフォルダの`.env.dist`ファイルにDB接続情報を記述します。
 
 ```
-TKT_DB_HOST=127.0.0.1
+TKT_DB_HOST=127.0.0.1:3306
 TKT_DB_NAME=ticket
 TKT_DB_USER=root
 TKT_DB_PASS=''
 TKT_DB_SLAVE=''
-TKT_DB_DSN=mysql:host=${TKT_DB_HOST};dbname=${TKT_DB_NAME}
+TKT_DB_DSN=mysql:host=${TKT_DB_HOST}
 ```
 
 `.env.dist`ファイルはこのようにして、実際の接続情報は`.env`に記述しましょう。[^1]
@@ -136,6 +136,16 @@ final class Ticket extends AbstractMigration
             ->create();
     }
 }
+```
+
+`.env.dist`ファイルを以下のように変更します。
+
+```diff
+ TKT_DB_USER=root
+ TKT_DB_PASS=
+ TKT_DB_SLAVE=
+-TKT_DB_DSN=mysql:host=${TKT_DB_HOST}
++TKT_DB_DSN=mysql:host=${TKT_DB_HOST};dbname=${TKT_DB_NAME}
 ```
 
 準備が完了したので、セットアップコマンドを実行してテーブルを作成します。


### PR DESCRIPTION
Fix #193 

- `TKT_DB_HOST` に mysql の default port number を追加しました。
- migrationの実行時とsetupの実行時の `TKT_DB_DSN` の変更を行うようにしました。 