### PR TITLE
fix code

### DIFF
--- a/manuals/1.0/en/tutorial.md
+++ b/manuals/1.0/en/tutorial.md
@@ -930,8 +930,13 @@ In order to enable caching , create the context of `bin/app.php` `test` for cach
 
 ```php
 <?php
+
+declare(strict_types=1);
+
+use MyVendor\Weekday\Bootstrap;
+
 require dirname(__DIR__) . '/autoload.php';
-exit((require dirname(__DIR__) . '/bootstrap.php')('prod-cli-hal-api-app'));
+exit(( new Bootstrap() )('prod-cli-hal-api-app', $GLOBALS, $_SERVER));
 ```
 
 Request with console command. `POST`, but for convenience we pass parameters in the form of a query.

--- a/manuals/1.0/ja/tutorial.md
+++ b/manuals/1.0/ja/tutorial.md
@@ -956,8 +956,13 @@ class Todos extends ResourceObject
 
 ```php
 <?php
+
+declare(strict_types=1);
+
+use MyVendor\Weekday\Bootstrap;
+
 require dirname(__DIR__) . '/autoload.php';
-exit((require dirname(__DIR__) . '/bootstrap.php')('prod-cli-hal-api-app'));
+exit(( new Bootstrap() )('prod-cli-hal-api-app', $GLOBALS, $_SERVER));
 ```
 
 コンソールコマンドでリクエストします。`POST`ですがBEAR.Sundayではクエリーの形でパラメーターを渡します。


### PR DESCRIPTION
php8.0.0のバージョンでマニュアルを進めていましたが、
途中で動作しない箇所がありました。
(https://bearsunday.github.io/manuals/1.0/ja/tutorial.html#post%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88)

gitでbearsunday/tutorial1に記載されたコードを書くと、動作しましたので、
こちらのコードをマニュアルに記載して頂けると、チュートリアルをよりすすめやすいのではと思いました。
https://github.com/bearsunday/tutorial1/blob/v2/bin/test.php


また、現状のマニュアルではprod-cli-hal-api-appのみが記載されているため、
ここの箇所では三項演算子を使用せず、'prod-cli-hal-api-app'のみを指定しました。

PHP_SAPI === 'cli'でない場合に言及する際は
`curl`コマンドを使用する直前などに改めて追加すると
マニュアルの流れがより追いやすくなるのではと思いました。


ご確認宜しくお願いします。