### PR TITLE
Fix html v2 manual

### DIFF
--- a/manuals/1.0/en/html-v2.md
+++ b/manuals/1.0/en/html-v2.md
@@ -54,7 +54,7 @@ example）
 `src/Page/Index.php`
 
 ```php
-class Index extend ResourceObject
+class Index extends ResourceObject
 {
     public $body = [
         ['greeting' => 'Hello BEAR.Sunday']
@@ -136,8 +136,8 @@ class Todos extend ResourceObject
     public $code = 200;
 
     public $text = [
-        'name' => 'BEAR';
-    ];    
+        'name' => 'BEAR'
+    ];
 
     public $body = [
         ['title' => 'run']
@@ -171,7 +171,7 @@ class Todos extends ResourceObject
 
     public function onGet() : ResourceObject
     {
-        $this->body = $this->pdo->fetchAll($this->query['todos_list'])
+        $this->body = $this->pdo->fetchAll($this->query['todos_list']);
         return $this;
     }
 }

--- a/manuals/1.0/en/html-v2.md
+++ b/manuals/1.0/en/html-v2.md
@@ -57,7 +57,7 @@ example）
 class Index extends ResourceObject
 {
     public $body = [
-        ['greeting' => 'Hello BEAR.Sunday']
+        'greeting' => 'Hello BEAR.Sunday'
     ];
 }
 ```
@@ -140,7 +140,7 @@ class Todos extend ResourceObject
     ];
 
     public $body = [
-        ['title' => 'run']
+        'title' => 'run'
     ];
 }
 ```

--- a/manuals/1.0/en/html-v2.md
+++ b/manuals/1.0/en/html-v2.md
@@ -140,7 +140,7 @@ class Todos extend ResourceObject
     ];
 
     public $body = [
-        'title' => 'run'
+        ['title' => 'run']
     ];
 }
 ```

--- a/manuals/1.0/ja/html-v2.md
+++ b/manuals/1.0/ja/html-v2.md
@@ -47,7 +47,7 @@ cp -r vendor/madapaja/twig-module/var/templates var/templates
 `bin/page.php`や`public/index.php`のコンテキストを変更して`html`を有効にします。
 
 ```bash
-$context = 'cli-html-app'; // 'htm-app'
+$context = 'cli-html-app'; // 'html-app'
 ```
 ## テンプレート
 

--- a/manuals/1.0/ja/html-v2.md
+++ b/manuals/1.0/ja/html-v2.md
@@ -64,7 +64,7 @@ $context = 'cli-html-app'; // 'htm-app'
 class Index extends ResourceObject
 {
     public $body = [
-        ['greeting' => 'Hello BEAR.Sunday']
+        'greeting' => 'Hello BEAR.Sunday'
     ];
 }
 ```
@@ -146,7 +146,7 @@ class Todos extend ResourceObject
     ];
 
     public $body = [
-        ['title' => 'run']
+        'title' => 'run'
     ];
 }
 ```

--- a/manuals/1.0/ja/html-v2.md
+++ b/manuals/1.0/ja/html-v2.md
@@ -146,7 +146,7 @@ class Todos extend ResourceObject
     ];
 
     public $body = [
-        'title' => 'run'
+        ['title' => 'run']
     ];
 }
 ```

--- a/manuals/1.0/ja/html-v2.md
+++ b/manuals/1.0/ja/html-v2.md
@@ -61,7 +61,7 @@ $context = 'cli-html-app'; // 'htm-app'
 `src/Page/Index.php`
 
 ```php
-class Index extend ResourceObject
+class Index extends ResourceObject
 {
     public $body = [
         ['greeting' => 'Hello BEAR.Sunday']
@@ -142,8 +142,8 @@ class Todos extend ResourceObject
     public $code = 200;
 
     public $text = [
-        'name' => 'BEAR';
-    ];    
+        'name' => 'BEAR'
+    ];
 
     public $body = [
         ['title' => 'run']
@@ -177,7 +177,7 @@ class Todos extends ResourceObject
 
     public function onGet() : ResourceObject
     {
-        $this->body = $this->pdo->fetchAll($this->query['todos_list'])
+        $this->body = $this->pdo->fetchAll($this->query['todos_list']);
         return $this;
     }
 }


### PR DESCRIPTION
- PHP の構文エラーが発生する箇所があったので直しました
- typo があったので直しました
  - `htm` -> `html`
- 例のままでは動かないコードがあったので直しました
  - > テンプレートにリソースの bodyがアサインされます。
  - こちらの記述があったので配列の中に配列を入れると例の通りでは動かないと思ったので消しました。間違いでしたら教えてください。