### PR TITLE
QiqのページでappDirの取得方法を変更

### DIFF
--- a/manuals/1.0/en/html-qiq.md
+++ b/manuals/1.0/en/html-qiq.md
@@ -35,7 +35,8 @@ class HtmlModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new QiqModule($this->appDir . '/var/qiq/template'));
+        $appMeta = new AppMeta('MyVendor\MyPackage');
+        $this->install(new QiqModule($appMeta->appDir . '/var/qiq/template'));
     }
 }
 ```

--- a/manuals/1.0/ja/html-qiq.md
+++ b/manuals/1.0/ja/html-qiq.md
@@ -35,7 +35,8 @@ class HtmlModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new QiqModule($this->appDir . '/var/qiq/template'));
+        $appMeta = new AppMeta('MyVendor\MyPackage');
+        $this->install(new QiqModule($appMeta->appDir . '/var/qiq/template'));
     }
 }
 ```


### PR DESCRIPTION
Qiqのページの `HtmlModule.php` で `$this->appDir` が `null` になってしまうため、取得方法を変更しました。

これは未適用のプルリクエスト #226 とコンフリクトします。
#226 では `dirname(__DIR__, 2)` を使っているのに対して、こちらは `AppMeta` を使う方法で記述しました。