### PR TITLE
Fix layout collapse in ja coding guide

### DIFF
--- a/manuals/1.0/ja/coding-guide.md
+++ b/manuals/1.0/ja/coding-guide.md
@@ -180,4 +180,5 @@ BEAR.SundayはHTMLのWebフォームで`POST`リクエストの時に`X-HTTP-Met
 ## HTMLテンプレート
 
 * 大きなループ文を避けます。ループの中のif文は[ジェネレーター](https://www.php.net/manual/ja/language.generators.overview.php) で置き換えれないか検討しましょう。
+
 ---


### PR DESCRIPTION
直近の更新により添付画像の角丸赤枠部分の通り「コーディングガイド」ページの末尾にてレイアウト崩れが生じていました。
<img width="500" alt="bear_coding_guide_layout_collapse" src="https://user-images.githubusercontent.com/79107744/217549002-11932924-c883-47ff-8206-5d2a1dff6bdc.png">