### PR TITLE
チュートリアルのテンプレートの曜日参照箇所を修正

### DIFF
--- a/manuals/1.0/en/tutorial.md
+++ b/manuals/1.0/en/tutorial.md
@@ -793,7 +793,7 @@ In this way `text/html` media output can be set. Lastly, save your Twig template
 {% raw %}{% extends 'layout/base.html.twig' %}
 {% block title %}Weekday{% endblock %}
 {% block content %}
-The weekday of {{ year }}/{{ month }}/{{ day }} is {{ weekday.weekday }}.
+The weekday of {{ year }}/{{ month }}/{{ day }} is {{ weekday }}.
 {% endblock %}{% endraw %}
 ```
 

--- a/manuals/1.0/ja/tutorial.md
+++ b/manuals/1.0/ja/tutorial.md
@@ -804,7 +804,7 @@ exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-html-app' : 'html-app', $GLOBAL
 {% raw %}{% extends 'layout/base.html.twig' %}
 {% block title %}Weekday{% endblock %}
 {% block content %}
-The weekday of {{ year }}/{{ month }}/{{ day }} is {{ weekday.weekday }}.
+The weekday of {{ year }}/{{ month }}/{{ day }} is {{ weekday }}.
 {% endblock %}{% endraw %}
 ```
 


### PR DESCRIPTION
下記のPageリソースのbodyの構造に対してテンプレートが対応する形式になっておらず、`weekday`がテンプレート側に正常に出力されていませんでしたので修正しました。
```
    public function onGet(int $year, int $month, int $day): static
    {
        $weekday = $this->weekday->onGet($year, $month, $day);
        $this->body = [
            'year' => $year,
            'month' => $month,
            'day' => $day,
            'weekday' => $weekday->body['weekday']
        ];

        return $this;
    }
```