### PR TITLE
Add reference documentation in English and Japanese

### DIFF
--- a/_includes/manuals/1.0/en/contents.html
+++ b/_includes/manuals/1.0/en/contents.html
@@ -122,6 +122,9 @@
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/en/apidoc.html' %}active{% endif %}" href="/manuals/1.0/en/apidoc.html">API Doc</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link {% if page.permalink == '/manuals/1.0/en/reference.html' %}active{% endif %}" href="/manuals/1.0/en/reference.html">Reference</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/en/1page.html' %}active{% endif %}" href="/manuals/1.0/en/1page.html">1 Page</a>
             </li>
         </ul>

--- a/_includes/manuals/1.0/ja/contents.html
+++ b/_includes/manuals/1.0/ja/contents.html
@@ -125,6 +125,9 @@
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/apidoc.html' %}active{% endif %}" href="/manuals/1.0/ja/apidoc.html">API Doc</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/reference.html' %}active{% endif %}" href="/manuals/1.0/ja/reference.html">リファレンス</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/1page.html' %}active{% endif %}" href="/manuals/1.0/ja/1page.html">1 Page</a>
             </li>
         </ul>

--- a/manuals/1.0/en/350.reference.md
+++ b/manuals/1.0/en/350.reference.md
@@ -1,0 +1,67 @@
+---
+layout: docs-en
+title: Reference
+category: Manual
+permalink: /manuals/1.0/en/reference.html
+---
+
+# Reference
+
+## Attributes
+
+| Attribute | Description |
+| --- | --- |
+| `#[CacheableResponse]` | An attribute to indicate a cacheable response. |
+| `#[Cacheable(int $expirySecond = 0)]` | An attribute to indicate the cacheability of a resource. `$expirySecond` is the cache expiration time in seconds. |
+| `#[CookieParam(string $name)]` | An attribute to receive parameters from cookies. `$name` is the name of the cookie. |
+| `#[DonutCache]` | An attribute to indicate Donut cache. |
+| `#[Embed(src: string $src, rel: string $rel)]` | An attribute to indicate embedding other resources. `$src` is the URI of the embedded resource, `$rel` is the relation name. |
+| `#[EnvParam(string $name)]` | An attribute to receive parameters from environment variables. `$name` is the name of the environment variable. |
+| `#[FormParam(string $name)]` | An attribute to receive parameters from form data. `$name` is the name of the form field. |
+| `#[Inject]` | An attribute to indicate setter injection. |
+| `#[InputValidation]` | An attribute to indicate input validation. |
+| `#[JsonSchema(key: string $key = null, schema: string $schema = null, params: string $params = null)]` | An attribute to specify the JSON schema for input/output of a resource. `$key` is the schema key, `$schema` is the schema file name, `$params` is the schema file name for parameters. |
+| `#[Link(rel: string $rel, href: string $href, method: string $method = null)]` | An attribute to indicate links between resources. `$rel` is the relation name, `$href` is the URI of the linked resource, `$method` is the HTTP method. |
+| `#[Named(string $name)]` | An attribute to indicate named binding. `$name` is the binding name. |
+| `#[OnFailure(string $name = null)]` | An attribute to specify a method for validation failure. `$name` is the name of the validation. |
+| `#[OnValidate(string $name = null)]` | An attribute to specify a validation method. `$name` is the name of the validation. |
+| `#[Produces(array $mediaTypes)]` | An attribute to specify the output media types of a resource. `$mediaTypes` is an array of producible media types. |
+| `#[QueryParam(string $name)]` | An attribute to receive query parameters. `$name` is the name of the query parameter. |
+| `#[RefreshCache]` | An attribute to indicate cache refresh. |
+| `#[ResourceParam(uri: string $uri, param: string $param)]` | An attribute to receive the result of another resource as a parameter. `$uri` is the URI of the resource, `$param` is the parameter name. |
+| `#[ReturnCreatedResource]` | An attribute to indicate that the created resource will be returned. |
+| `#[ServerParam(string $name)]` | An attribute to receive parameters from server variables. `$name` is the name of the server variable. |
+| `#[Ssr(app: string $appName, state: array $state = [], metas: array $metas = [])]` | An attribute to indicate server-side rendering. `$appName` is the name of the JS application, `$state` is the state of the application, `$metas` is an array of meta information. |
+| `#[Transactional(array $props = ['pdo'])]` | An attribute to indicate that a method will be executed within a transaction. `$props` is an array of properties to which the transaction will be applied. |
+| `#[UploadFiles]` | An attribute to receive uploaded files. |
+| `#[Valid(form: string $form = null, onFailure: string $onFailure = null)]` | An attribute to indicate request validation. `$form` is the form class name, `$onFailure` is the method name for validation failure. |
+
+## Modules
+
+| Module Name | Description |
+| --- | --- |
+| `ApcSsrModule` | A module for server-side rendering using APCu. |
+| `ApiDoc` | A module for generating API documentation. |
+| `AppModule` | The main module of the application. It installs and configures other modules. |
+| `AuraSqlModule` | A module for database connection using Aura.Sql. |
+| `AuraSqlQueryModule` | A module for query builder using Aura.SqlQuery. |
+| `CacheVersionModule` | A module for cache version management. |
+| `CliModule` | A module for command-line interface. |
+| `DoctrineOrmModule` | A module for database connection using Doctrine ORM. |
+| `FakeModule` | A fake module for testing purposes. |
+| `HalModule` | A module for HAL (Hypertext Application Language). |
+| `HtmlModule` | A module for HTML rendering. |
+| `ImportAppModule` | A module for loading other applications. |
+| `JsonSchemaModule` | A module for input/output validation of resources using JSON schema. |
+| `JwtAuthModule` | A module for authentication using JSON Web Token (JWT). |
+| `NamedPdoModule` | A module that provides named PDO instances. |
+| `PackageModule` | A module that installs the basic modules provided by BEAR.Package together. |
+| `ProdModule` | A module for production environment settings. |
+| `QiqModule` | A module for the Qiq template engine. |
+| `ResourceModule` | A module for settings related to resource classes. |
+| `AuraRouterModule` | A module for routing using Aura.Router. |
+| `SirenModule` | A module for Siren (Hypermedia Specification). |
+| `SpyModule` | A module for recording method calls. |
+| `SsrModule` | A module for server-side rendering. |
+| `TwigModule` | A module for the Twig template engine. |
+| `ValidationModule` | A module for validation. |

--- a/manuals/1.0/ja/350.reference.md
+++ b/manuals/1.0/ja/350.reference.md
@@ -1,0 +1,67 @@
+---
+layout: docs-ja
+title: レファレンス
+category: Manual
+permalink: /manuals/1.0/ja/reference.html
+---
+
+# リファレンス
+
+## アトリビュート
+
+| アトリビュート | 説明                                                                                           |
+|---|----------------------------------------------------------------------------------------------|
+| `#[CacheableResponse]` | キャッシュ可能なレスポンスを指定するアトリビュート。                                                                   |
+| `#[Cacheable(int $expirySecond = 0)]` | リソースのキャッシュ可能性を指定するアトリビュート。`$expirySecond` はキャッシュの有効期間（秒）。                                    |
+| `#[CookieParam(string $name)]` | クッキーからパラメータを受け取るためのアトリビュート。`$name` はクッキーの名前。                                                 |
+| `#[DonutCache]` | ドーナツキャッシュを指定するアトリビュート。                                                                       |
+| `#[Embed(src: string $src, rel: string $rel)]` | 他のリソースを埋め込むことを指定するアトリビュート。`$src` は埋め込むリソースのURI、`$rel` はリレーション名。                              |
+| `#[EnvParam(string $name)]` | 環境変数からパラメータを受け取るためのアトリビュート。`$name` は環境変数の名前。                                                 |
+| `#[FormParam(string $name)]` | フォームデータからパラメータを受け取るためのアトリビュート。`$name` はフォームフィールドの名前。                                         |
+| `#[Inject]` | セッターインジェクションを指定するアトリビュート。                                                             |
+| `#[InputValidation]` | 入力バリデーションを行うことを指定するアトリビュート。                                                                  |
+| `#[JsonSchema(key: string $key = null, schema: string $schema = null, params: string $params = null)]` | リソースの入力/出力のJSONスキーマを指定するアトリビュート。`$key` はスキーマのキー、`$schema` はスキーマファイル名、`$params` はパラメータのスキーマファイル名。 |
+| `#[Link(rel: string $rel, href: string $href, method: string $method = null)]` | リソース間のリンクを指定するアトリビュート。`$rel` はリレーション名、`$href` はリンク先のURI、`$method` はHTTPメソッド。                 |
+| `#[Named(string $name)]` | 名前付きバインディングを指定するアトリビュート。`$name` はバインディングの名前。                                                 |
+| `#[OnFailure(string $name = null)]` | バリデーション失敗時のメソッドを指定するアトリビュート。`$name` はバリデーションの名前。                                             |
+| `#[OnValidate(string $name = null)]` | バリデーションメソッドを指定するアトリビュート。`$name` はバリデーションの名前。                                                 |
+| `#[Produces(array $mediaTypes)]` | リソースの出力メディアタイプを指定するアトリビュート。`$mediaTypes` は出力可能なメディアタイプの配列。                                   |
+| `#[QueryParam(string $name)]` | クエリパラメータを受け取るためのアトリビュート。`$name` はクエリパラメータの名前。                                                |
+| `#[RefreshCache]` | キャッシュのリフレッシュを指定するアトリビュート。                                                                    |
+| `#[ResourceParam(uri: string $uri, param: string $param)]` | 他のリソースの結果をパラメータとして受け取るためのアトリビュート。`$uri` はリソースのURI、`$param` はパラメータ名。                          |
+| `#[ReturnCreatedResource]` | 作成されたリソースを返すことを指定するアトリビュート。                                                                  |
+| `#[ServerParam(string $name)]` | サーバー変数からパラメータを受け取るためのアトリビュート。`$name` はサーバー変数の名前。                                             |
+| `#[Ssr(app: string $appName, state: array $state = [], metas: array $metas = [])]` | サーバーサイドレンダリングを指定するアトリビュート。`$appName` はJSアプリケーション名、`$state` はアプリケーションの状態、`$metas` はメタ情報の配列。   |
+| `#[Transactional(array $props = ['pdo'])]` | メソッドをトランザクション内で実行することを指定するアトリビュート。`$props` はトランザクションを適用するプロパティの配列。                           |
+| `#[UploadFiles]` | アップロードされたファイルを受け取るためのアトリビュート。                                                                |
+| `#[Valid(form: string $form = null, onFailure: string $onFailure = null)]` | リクエストの検証を行うことを指定するアトリビュート。`$form` はフォームクラス名、`$onFailure` は検証失敗時のメソッド名。                       |
+
+## モジュール
+
+| モジュール名               | 説明                                               |
+|----------------------|--------------------------------------------------|
+| `ApcSsrModule`       | APCuを使用したサーバーサイドレンダリング用のモジュール。                   |
+| `ApiDoc`             | APIドキュメントを生成するためのモジュール。                          |
+| `AppModule`          | アプリケーションのメインモジュール。他のモジュールのインストールや設定を行う。          |
+| `AuraSqlModule`      | Aura.Sqlを使用したデータベース接続用のモジュール。                    |
+| `AuraSqlQueryModule` | Aura.SqlQueryを使用したクエリビルダー用のモジュール。                |
+| `CacheVersionModule` | キャッシュのバージョン管理を行うモジュール。                           |
+| `CliModule`          | コマンドラインインターフェース用のモジュール。                          |
+| `DoctrineOrmModule`  | Doctrine ORMを使用したデータベース接続用のモジュール。                |
+| `FakeModule`         | テスト用のフェイクモジュール。                                  |
+| `HalModule`          | HAL (Hypertext Application Language) 用のモジュール。    |
+| `HtmlModule`         | HTMLレンダリング用のモジュール。                               |
+| `ImportAppModule`    | 他のアプリケーションを読み込むためのモジュール。                         |
+| `JsonSchemaModule`   | JSONスキーマを使用したリソースの入力/出力バリデーション用のモジュール。           |
+| `JwtAuthModule`      | JSON Web Token (JWT) を使用した認証用のモジュール。             |
+| `NamedPdoModule`     | 名前付きのPDOインスタンスを提供するモジュール。                        |
+| `PackageModule`      | BEAR.Packageが提供する基本的なモジュールをまとめてインストールするためのモジュール。 |
+| `ProdModule`         | 本番環境用の設定を行うモジュール。                                |
+| `QiqModule`          | Qiqテンプレートエンジン用のモジュール。                            |
+| `ResourceModule`     | リソースクラスに関する設定を行うモジュール。                           |
+| `AuraRouterModule`   | Aura.Routerのルーティング用のモジュール。                       |
+| `SirenModule`        | Siren (Hypermedia Specification) 用のモジュール。        |
+| `SpyModule`          | メソッドの呼び出しを記録するためのモジュール。                          |
+| `SsrModule`          | サーバーサイドレンダリング用のモジュール。                            |
+| `TwigModule`         | Twigテンプレートエンジン用のモジュール。                           |
+| `ValidationModule`   | バリデーション用のモジュール。                                  |


### PR DESCRIPTION
This commit introduces a new reference documentation in both English and Japanese, detailing attributes and modules within the system. The documentation provides explanations for each attribute and module, enabling easier understanding of system functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Reference" section to the English and Japanese manuals, providing detailed guides on system attributes and modules.
- **Documentation**
	- Updated the contents page in both English and Japanese versions to include navigation to the new "Reference" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->