### PR TITLE
Add "Self linking" section to resource link documentation

### DIFF
--- a/manuals/1.0/en/130.resource_link.md
+++ b/manuals/1.0/en/130.resource_link.md
@@ -79,6 +79,24 @@ class News extends ResourceObject
         $this->body['website']->addQuery(['title' => $title]); // 引数追加
 ```
 
+### Self linking
+
+Linking a relation as `_self` in ``#[Embed]`` copies the linked resource state to its own resource state.
+
+```php
+namespace MyVendor\Weekday\ResourcePage;.
+
+class Weekday extends ResourceObject
+{
+#[Embed(rel: '_self', src: 'app://self/weekday{?year,month,day}'])
+public function onGet(string $id): static
+{
+```
+
+In this example, the Page resource copies the state of the `weekday` resource of the App resource to itself.
+
+### Internal links in HAL
+
 Handled as `_embedded ` in the [HAL](https://github.com/blongden/hal) renderer.
 
 ## Link request

--- a/manuals/1.0/ja/130.resource_link.md
+++ b/manuals/1.0/ja/130.resource_link.md
@@ -79,6 +79,24 @@ class News extends ResourceObject
         $this->body['website']->addQuery(['title' => $title]); // 引数追加
 ```
 
+### セルフリンク
+
+`#[Embed]`でリレーションを`_self`としてリンクすると、リンク先のリソース状態を自身のリソース状態にコピーします。
+
+```php
+namespace MyVendor\Weekday\Resource\Page;
+
+class Weekday extends ResourceObject
+{
+    #[Embed(rel: '_self', src: 'app://self/weekday{?year,month,day}']
+    public function onGet(string $id): static
+    {
+```
+
+この例ではPageリソースのがAppリソースの`weekday`リソースの状態を自身にコピーしています。
+
+### HALでの内部リンク
+
 [HAL](https://github.com/blongden/hal)レンダラーでは`_embedded `として扱われます。
 
 ## リンクリクエスト


### PR DESCRIPTION
Added a new section about self linking in the resource link documentation, explaining how a linked resource state is

Introduced at [BEAR.Resource v1.22](https://github.com/bearsunday/BEAR.Resource/releases/tag/1.22.0)