### PR TITLE
Add Multilingual Framework section to manuals

### DIFF
--- a/manuals/1.0/en/170.import.md
+++ b/manuals/1.0/en/170.import.md
@@ -105,3 +105,7 @@ Environment variables are global. Care should be taken to prefix them to avoid c
 It is similar to microservices in that a large application can be built as a collection of multiple smaller applications, but without the disadvantages of microservices such as increased infrastructure overhead. It also has clearer component independence and boundaries than modular monoliths.
 
 The code for this page can be found at [bearsunday/example-app-import](https://github.com/bearsunday/example-import-app/commits/master).
+
+## Multilingual Framework
+
+Using [BEAR.Thrift](https://github.com/bearsunday/BEAR.Thrift), you can access resources from other languages, different versions of PHP, or BEAR applications using Apache Thrift. [Apache Thrift](https://thrift.apache.org/) is a framework that enables efficient communication between different languages.

--- a/manuals/1.0/ja/170.import.md
+++ b/manuals/1.0/ja/170.import.md
@@ -109,3 +109,8 @@ echo $weekdday->body['weekday'] . PHP_EOL;
 大きなアプリケーションを小さな複数のアプリケーションの集合体として構築できる点はマイクロサービスと同じですが、インフラストラクチャのオーバーヘッドの増加などのマイクロサービスのデメリットがありません。 またモジュラーモノリスよりもコンポーネントの独立性や境界が明確です。
 
 このページのコードは [bearsunday/example-app-import](https://github.com/bearsunday/example-import-app/commits/master) にあります。
+
+## 多言語フレームワーク
+
+[BEAR.Thrfit](https://github.com/bearsunday/BEAR.Thrift)を使うと、Apache Thriftを使って他の言語や異なるバージョンのPHPやBEARアプリケーションからリソースにアクセスできます。
+[Apache Thrift](https://thrift.apache.org/)は、異なる言語間での効率的な通信を可能にするフレームワークです。

--- a/manuals/1.0/ja/170.import.md
+++ b/manuals/1.0/ja/170.import.md
@@ -112,5 +112,5 @@ echo $weekdday->body['weekday'] . PHP_EOL;
 
 ## 多言語フレームワーク
 
-[BEAR.Thrfit](https://github.com/bearsunday/BEAR.Thrift)を使うと、Apache Thriftを使って他の言語や異なるバージョンのPHPやBEARアプリケーションからリソースにアクセスできます。
+[BEAR.Thrift](https://github.com/bearsunday/BEAR.Thrift)を使うと、Apache Thriftを使って他の言語や異なるバージョンのPHPやBEARアプリケーションからリソースにアクセスできます。
 [Apache Thrift](https://thrift.apache.org/)は、異なる言語間での効率的な通信を可能にするフレームワークです。


### PR DESCRIPTION
The Multilingual Framework section has been added to the Japanese and English versions of the 170.import.md manual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced manuals with a new section on using the Multilingual Framework through BEAR.Thrift for accessing resources across different languages and PHP versions via Apache Thrift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->