### PR TITLE
Add 'copy to clipboard' functionality for headers

### DIFF
--- a/_includes/manuals/1.0/footer.html
+++ b/_includes/manuals/1.0/footer.html
@@ -18,7 +18,7 @@
                 <a href="https://www.facebook.com/pages/BEARSunday/110116939178462?ref=hl">Facebook</a>
             </li>
             <li>
-                <a href="http://koriym.github.io/">Blog (JA)</a>
+                <a href="https://koriym.github.io/">Blog (JA)</a>
             </li>
             <li>
                 <a href="https://github.com/bearsunday/bearsunday.github.io">PR ?</a>

--- a/_includes/manuals/1.0/footer.html
+++ b/_includes/manuals/1.0/footer.html
@@ -37,20 +37,8 @@
 <script src="https://www.google-analytics.com/analytics.js" async defer></script>
 {% if page.category == 'Manual' %}
 <script src="/js/generate-table-of-contents/index.min.js"></script>
-<script>
-    var toc = generateTableOfContents(document.getElementById('article'));
-    var sideBarRight = $('.side-bar-right');
-    sideBarRight.append(toc);
 
-    var scrollOffset = $('body').attr('data-offset');
-    var articlePaddingTop = $('article').css('padding-top').replace('px', '');
-    sideBarRight.find('a').on('click', function (e) {
-        e.preventDefault();
-        var targetId = $(this).attr('href');
-        var targetPositionTop = $(targetId).offset().top - scrollOffset - articlePaddingTop;
-        window.scrollTo(0, targetPositionTop)
-    });
-</script>
+<script src="/js/copy_link.js"></script>
 {% endif %}
 </body>
 </html>

--- a/js/copy_header_link.js
+++ b/js/copy_header_link.js
@@ -1,0 +1,22 @@
+// Copy the inline link to clipboard when clicking on the header
+const HEADING_TAGS = 'h1, h2, h3, h4';
+const changeCursorToPointer = (e) => {
+    e.target.style.cursor = 'pointer';
+};
+const copyInlineLinkToClipboard = async (e) => {
+    const el = document.createElement('textarea');
+    el.value = window.location.href.split('#')[0] + '#' + e.target.id;
+    document.body.appendChild(el);
+    el.select();
+    try {
+        await navigator.clipboard.writeText(el.value);
+        alert('Inline link copied to clipboard!');
+    } catch (err) {
+        console.error('Failed to copy inline link: ', err);
+    }
+    document.body.removeChild(el);
+};
+document.querySelectorAll(HEADING_TAGS).forEach((elem) => {
+    elem.addEventListener('mouseover', changeCursorToPointer);
+    elem.addEventListener('click', copyInlineLinkToClipboard);
+});


### PR DESCRIPTION
A new JavaScript file, 'copy_header_link.js', has been added to introduce a functionality that allows users to copy the inline link of a header to the clipboard upon clicking. This helps with easy sharing and referencing. Some unnecessary code has also been removed from