### PR TITLE
manual 1.0: fix syntax error on sample code of Doctrine DBAL

### DIFF
--- a/manuals/1.0/en/183.database.dbal.md
+++ b/manuals/1.0/en/183.database.dbal.md
@@ -25,7 +25,7 @@ class AppModule extends AbstractAppModule
     protected function configure()
     {
         // ...
-        $this->install(new DbalModule('driver=pdo_sqlite&memory=true');
+        $this->install(new DbalModule('driver=pdo_sqlite&memory=true'));
     }
 }
 ```

--- a/manuals/1.0/ja/183.database.dbal.md
+++ b/manuals/1.0/ja/183.database.dbal.md
@@ -26,7 +26,7 @@ class AppModule extends AbstractAppModule
     protected function configure()
     {
         // ...
-        $this->install(new DbalModule('driver=pdo_sqlite&memory=true');
+        $this->install(new DbalModule('driver=pdo_sqlite&memory=true'));
     }
 }
 ```


### PR DESCRIPTION
I found a syntax error on 
https://github.com/bearsunday/bearsunday.github.io/blob/master/manuals/1.0/en/183.database.dbal.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- `AppModule` クラスの `configure` メソッド内における構文エラーを修正しました。これにより、コードの安定性と正確性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->