### PR TITLE
Add Redis DSN configuration guide in Japanese

### DIFF
--- a/manuals/1.0/ja/186.redis-dsn.md
+++ b/manuals/1.0/ja/186.redis-dsn.md
@@ -1,0 +1,157 @@
+# Redis キャッシュアダプター
+
+Note: このドキュメントは[symfony/cacheのドキュメント](https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html#configure-the-connection)をRedisのDSN設定の部分だけを抽出して加工したものです。
+
+Redisアダプターは、1つ（または複数）の Redis サーバーインスタンスを使用してメモリ内に値を格納します。
+
+APCu アダプターとは異なり、そして Memcached アダプターと同様に、現在のサーバーの共有メモリに制限されません。PHP 環境に依存せずにコンテンツを保存できます。冗長性やフェイルオーバーを提供するサーバークラスターを利用する機能も利用可能です。
+
+> 注意:
+> 要件: このアダプターを使用するには、少なくとも1つの Redis サーバーがインストールされ、実行されている必要があります。さらに、このアダプターには `\Redis`、`\RedisArray`、`RedisCluster`、`\Relay\Relay`、または `\Predis` を実装する互換性のある拡張機能またはライブラリが必要です。
+
+このアダプターは、最初のパラメータとして `Redis`、`RedisArray`、`RedisCluster`、`Relay`、または `Predis` インスタンスを渡すことを期待します。名前空間とデフォルトのキャッシュ有効期間は、オプションで2番目と3番目のパラメータとして渡すことができます:
+
+## 接続の設定
+
+データソース名（DSN）を使用して Redis クライアントクラスインスタンスを作成および設定します:
+
+DSN は、IP/ホスト（およびオプションのポート）またはソケットパス、さらにパスワードとデータベースインデックスを指定できます。接続に TLS を有効にするには、スキーマ `redis` を `rediss` に置き換える必要があります（2番目の `s` は "secure" を意味します）。
+
+> 注意:
+> このアダプターのデータソース名（DSN）は、次のいずれかの形式を使用する必要があります。
+>
+> ```
+> redis[s]://[pass@][ip|host|socket[:port]][/db-index]
+> ```
+>
+> ```
+> redis[s]:[[user]:pass@]?[ip|host|socket[:port]][&params]
+> ```
+>
+> プレースホルダー `[user]`、`[:port]`、`[/db-index]`、`[&params]` の値はオプションです。
+
+以下は、利用可能な値の組み合わせを示す一般的な DSN の例です:
+
+```php
+
+// ホスト "my.server.com" とポート "6379"
+'redis://my.server.com:6379'
+
+// ホスト "my.server.com"、ポート "6379"、データベースインデックス "20"
+'redis://my.server.com:6379/20'
+
+// ホスト "localhost"、認証 "abcdef"、タイムアウト 5 秒
+'redis://abcdef@localhost?timeout=5'
+
+// ソケット "/var/run/redis.sock" と認証 "bad-pass"
+'redis://bad-pass@/var/run/redis.sock'
+
+// ホスト "redis1"（Docker コンテナ）、代替 DSN 構文を使用し、データベースインデックス "3" を選択
+'redis:?host[redis1:6379]&dbindex=3'
+
+// 代替 DSN 構文を使用した認証情報の提供
+'redis:default:verysecurepassword@?host[redis1:6379]&dbindex=3'
+
+// 単一の DSN で複数のサーバーを定義することもできます
+'redis:?host[localhost]&host[localhost:6379]&host[/var/run/redis.sock:]&auth=my-password&redis_cluster=1'
+```
+
+Redis の高可用性を提供する Redis Sentinel は、PHP Redis 拡張機能 v5.2+ または Predis ライブラリを使用する場合にサポートされています。サービスグループの名前を設定するには、`redis_sentinel` パラメータを使用します:
+
+```php
+'redis:?host[redis1:26379]&host[redis2:26379]&host[redis3:26379]&redis_sentinel=mymaster'
+
+// 認証情報の提供
+'redis:default:verysecurepassword@?host[redis1:26379]&host[redis2:26379]&host[redis3:26379]&redis_sentinel=mymaster'
+
+// 認証情報の提供とデータベースインデックス "3" の選択
+'redis:default:verysecurepassword@?host[redis1:26379]&host[redis2:26379]&host[redis3:26379]&redis_sentinel=mymaster&dbindex=3'
+```
+
+> 注意:
+> DSN パラメータとして渡すことができる他のオプションについては、`Symfony\Component\Cache\Traits\RedisTrait` を参照してください。
+
+
+### 利用可能なオプション
+
+`class` (型: `string`, デフォルト: `null`)
+返す接続ライブラリを指定します。`\Redis`、`\Relay\Relay`、または `\Predis\Client` のいずれかです。
+指定されていない場合、フォールバック値は次の順序で、最初に利用可能なものが使用されます:
+`\Redis`、`\Relay\Relay`、`\Predis\Client`。Sentinel を使用している場合にマスター情報の取得に問題が発生した場合は、明示的に `\Predis\Client` に設定してください。
+
+`persistent` (型: `int`, デフォルト: `0`)
+永続的な接続の使用を有効または無効にします。値が `0` の場合は永続的な接続を無効にし、
+値が `1` の場合は有効にします。
+
+`persistent_id` (型: `string|null`, デフォルト: `null`)
+永続的な接続に使用する永続的な ID 文字列を指定します。
+
+`timeout` (型: `int`, デフォルト: `30`)
+接続試行がタイムアウトするまでに Redis サーバーに接続するために使用される時間（秒単位）を指定します。
+
+`read_timeout` (型: `int`, デフォルト: `0`)
+基礎となるネットワークリソースで読み取り操作を実行する際に、操作がタイムアウトするまでに
+使用される時間（秒単位）を指定します。
+
+`retry_interval` (型: `int`, デフォルト: `0`)
+クライアントがサーバーとの接続を失った場合の再接続試行間の遅延（ミリ秒単位）を指定します。
+
+`tcp_keepalive` (型: `int`, デフォルト: `0`)
+接続の TCP キープアライブタイムアウト（秒単位）を指定します。これには
+phpredis v4 以上と TCP キープアライブが有効なサーバーが必要です。
+
+`lazy` (型: `bool`, デフォルト: `null`)
+バックエンドへの遅延接続を有効または無効にします。スタンドアロンコンポーネントとして
+使用する場合はデフォルトで `false` になり、Symfony アプリケーション内で使用する場合は
+デフォルトで `true` になります。
+
+`redis_cluster` (型: `bool`, デフォルト: `false`)
+Redis クラスターを有効または無効にします。実際に渡される値は関係ありません。緩い比較
+チェックを通過する限り、`redis_cluster=1` で十分です。
+
+`redis_sentinel` (型: `string`, デフォルト: `null`)
+センチネルに接続されているマスター名を指定します。
+
+`sentinel_master` (型: `string`, デフォルト: `null`)
+`redis_sentinel` オプションのエイリアスです。
+
+`dbindex` (型: `int`, デフォルト: `0`)
+選択するデータベースインデックスを指定します。
+
+`failover` (型: `string`, デフォルト: `none`)
+クラスター実装のフェイルオーバーを指定します。`\RedisCluster` の場合、有効なオプションは
+`none`（デフォルト）、`error`、`distribute`、または `slaves` です。`\Predis\ClientInterface` の
+場合、有効なオプションは `slaves` または `distribute` です。
+
+`ssl` (型: `array`, デフォルト: `null`)
+SSL コンテキストオプション。詳細については `php.net/context.ssl` を参照してください。
+
+> バージョン 7.1 で追加:
+> `sentinel_master` オプションが `redis_sentinel` のエイリアスとして Symfony 7.1 で導入されました。
+
+> 注意:
+> `Predis` ライブラリを使用する場合、いくつかの追加の Predis 固有のオプションが利用可能です。
+> 詳細については、`Predis 接続パラメータ` のドキュメントを参照してください。
+
+## Redis の設定
+
+Redis をキャッシュとして使用する場合、`maxmemory` と `maxmemory-policy` 設定を構成する必要があります。`maxmemory` を設定することで、Redis が消費できるメモリ量を制限します。量が少なすぎると、Redis はまだ有用なエントリを削除し、キャッシュの恩恵を受けられなくなります。`maxmemory-policy` を `allkeys-lru` に設定すると、メモリが不足した場合にデータを削除してもよいこと、そして最初に最も古いエントリ（最近使用されていないもの）を削除することを Redis に伝えます。Redis にエントリの削除を許可しない場合、メモリが利用できないときにデータを追加しようとするとエラーが返されます。設定例は次のようになります:
+
+```ini
+maxmemory 100mb
+maxmemory-policy allkeys-lru
+```
+
+[//]: # (以下はまだ未使用で不要な情報)
+
+[//]: # ()
+[//]: # (> 注意:)
+
+[//]: # (> RedisTagAwareAdapter を使用する場合、タグとキャッシュアイテム間の関係を維持するために、)
+
+[//]: # (> Redis の `maxmemory-policy` 退去ポリシーで `noeviction` または `volatile-*` のいずれかを)
+
+[//]: # (> 使用する必要があります。)
+
+[//]: # ()
+[//]: # (このトピックの詳細については、公式の `Redis LRU キャッシュドキュメント` をお読みください。)


### PR DESCRIPTION
Introduced a new manual page detailing Redis adapter configuration, usage, and options with examples. This document is based on Symfony's Cache component documentation specifically for Redis DSN settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Symfony向けのRedisキャッシュアダプターに関するドキュメントを追加しました。これにより、メモリ内に値を保存する機能や設定方法を詳述しています。
	- Redisサーバーの冗長性とフェイルオーバーをサポートし、信頼性を向上させることができます。

- **ドキュメント**
	- Redisクライアントクラスインスタンスの作成と構成方法についての詳細を提供しています。
	- Redis接続の構成オプションやキャッシュのための設定に関するガイドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->