### PR TITLE
Update Psalm documentation links in Japanese manual

### DIFF
--- a/manuals/1.0/ja/300.types.md
+++ b/manuals/1.0/ja/300.types.md
@@ -708,9 +708,9 @@ PHPDocの型システムを深く理解して適切に使用することで、�
 
 PHPDoc型を最大限に活用するためには、PsalmやPHPStanといった静的解析ツールが必要です。詳細については、以下のリソースを参照してください：
 
-- [Psalm - Typing in Psalm](https://psalm.dev/docs/annotating_code/typing_in_psalm/)
-  - [Atomic Types](https://psalm.dev/docs/annotating_code/type_syntax/atomic_types/)
-  - [Templating](https://psalm.dev/docs/annotating_code/templated_annotations/)
-  - [Assertions](https://psalm.dev/docs/annotating_code/adding_assertions/)
-  - [Security Analysis](https://psalm.dev/docs/security_analysis/)
+- [Psalm - Typing in Psalm](https://koriym.github.io/psalm-ja/annotating_code/typing_in_psalm/)
+  - [Atomic Types](https://koriym.github.io/psalm-ja/annotating_code/type_syntax/atomic_types/)
+  - [Templating](https://koriym.github.io/psalm-ja/annotating_code/templated_annotations/)
+  - [Assertions](https://koriym.github.io/psalm-ja/annotating_code/adding_assertions/)
+  - [Security Analysis](https://koriym.github.io/psalm-ja/security_analysis/)
 - [PHPStan - PHPDoc Types](https://phpstan.org/writing-php-code/phpdoc-types)


### PR DESCRIPTION
Changed the URLs in the Japanese PHPDoc section to point to the Japanese-translated Psalm documentation. This enhances accessibility for Japanese users looking for detailed information on using Psalm's typing features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 日本語版のPsalmドキュメントへのリンクを更新し、アクセスを向上させました。
		- 各種トピック（型付け、原子型、テンプレート、アサーション、セキュリティ分析）のリンクが変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->