### PR TITLE
Enhance CLI documentation to include Homebrew formulae support

### DIFF
--- a/manuals/1.0/en/325.cli.md
+++ b/manuals/1.0/en/325.cli.md
@@ -168,6 +168,8 @@ $ brew install --formula ./var/homebrew/greet.rb
 
 Method for wide distribution using a public repository:
 
+Note: The file name of the formula and the class name inside it are based on the name of the repository. For example, if the GH repository is `koriym/greet`, then `var/homebrew/greet.rb` will be generated, which contains the `Greet` class. In this case, `greet` will be the name of the tap that is published, but if you want to change it, please change the class name and file name of fomula script.
+
 ```bash
 $ brew tap your-vendor/greet
 $ brew install your-vendor/greet
@@ -200,11 +202,11 @@ $ git push origin v0.1.0
 ```diff
  class Greet < Formula
 +  desc "Your CLI tool description"
-+  homepage "https://github.com/your-vendor/your-project"
-+  url "https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz"
++  homepage "https://github.com/your-vendor/greet"
++  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
 +  sha256 "..." # Add hash value obtained from the command below
 +  version "0.1.0"
--  head "https://github.com/your-vendor/your-project.git", branch: "main"
+-  head "https://github.com/your-vendor/greet.git", branch: "main"
    
    depends_on "php@8.1"
    depends_on "composer"
@@ -216,7 +218,7 @@ You can add dependencies like databases to the formula as needed. However, it's 
 3. Get SHA256 hash:
 ```bash
 # Download tarball from GitHub and calculate hash
-$ curl -sL https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
+$ curl -sL https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
 ```
 
 4. Create Homebrew tap:
@@ -257,8 +259,8 @@ $ brew edit your-vendor/greet
 ```ruby
 class Greet < Formula
   desc "Your CLI tool description"
-  homepage "https://github.com/your-vendor/your-project"
-  url "https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz"
+  homepage "https://github.com/your-vendor/greet"
+  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "..." # tgz SHA256
   version "0.1.0"
   

--- a/manuals/1.0/en/325.cli.md
+++ b/manuals/1.0/en/325.cli.md
@@ -206,7 +206,7 @@ $ git push origin v0.1.0
 +  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
 +  sha256 "..." # Add hash value obtained from the command below
 +  version "0.1.0"
--  head "https://github.com/your-vendor/greet.git", branch: "main"
+   head "https://github.com/your-vendor/greet.git", branch: "main"
    
    depends_on "php@8.1"
    depends_on "composer"

--- a/manuals/1.0/ja/325.cli.md
+++ b/manuals/1.0/ja/325.cli.md
@@ -154,7 +154,9 @@ CLIコマンドの出力は以下の仕様に基づきます：
 ## 配布方法
 
 BEAR.Cliで作成したコマンドは、Homebrewを通じて配布できます。
-フォーミュラの生成にはアプリケーションがGitHubで公開されていることが必要です：
+フォーミュラの生成にはアプリケーションがGitHubで公開されていることが必要です。
+
+フォーミュラのファイル名および中のクラス名はリポジトリの名前に基づいています。例えばGHリポジトリが`koriym/greet`の場合、`Greet`クラスを含む`var/homebrew/greet.rb`が生成されます。この時`greet`が公開するタップ名になりますが変更したい場合はフォーミュラのクラス名とファイル名を変更してください。
 
 ### 1. ローカルフォーミュラによる配布
 
@@ -170,7 +172,7 @@ $ brew install --formula ./var/homebrew/greet.rb
 
 ```bash
 $ brew tap your-vendor/greet
-$ brew install your-vendor/greet
+$ brew install greet
 ```
 
 この方法は特に以下の場合に適しています：
@@ -200,11 +202,11 @@ $ git push origin v0.1.0
 ```diff
  class Greet < Formula
 +  desc "Your CLI tool description"
-+  homepage "https://github.com/your-vendor/your-project"
-+  url "https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz"
++  homepage "https://github.com/your-vendor/greet"
++  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
 +  sha256 "..." # 以下のコマンドで取得したハッシュ値を記述
 +  version "0.1.0"
--  head "https://github.com/your-vendor/your-project.git", branch: "main"
+-  head "https://github.com/your-vendor/greet.git", branch: "main"
    
    depends_on "php@8.1"
    depends_on "composer"
@@ -215,11 +217,12 @@ $ git push origin v0.1.0
 3. SHA256ハッシュの取得：
 ```bash
 # GitHubからtarballをダウンロードしてハッシュを計算
-$ curl -sL https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
+$ curl -sL https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
 ```
 
 4. Homebrewタップの作成:
    [GitHub CLI(gh)](https://cli.github.com/)または[github.com/new](https://github.com/new)でリポジトリを作成してください。公開リポジトリ名は`homebrew-`で始める必要があります。たとえば`homebrew-greet`です：
+
 ```bash
 $ gh auth login
 $ gh repo create your-vendor/homebrew-greet --public --clone
@@ -256,8 +259,8 @@ $ brew edit your-vendor/greet
 ```ruby
 class Greet < Formula
   desc "Your CLI tool description"
-  homepage "https://github.com/your-vendor/your-project"
-  url "https://github.com/your-vendor/your-project/archive/refs/tags/v0.1.0.tar.gz"
+  homepage "https://github.com/your-vendor/greet"
+  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "..." # tgzのSHA256
   version "0.1.0"
   

--- a/manuals/1.0/ja/325.cli.md
+++ b/manuals/1.0/ja/325.cli.md
@@ -206,7 +206,7 @@ $ git push origin v0.1.0
 +  url "https://github.com/your-vendor/greet/archive/refs/tags/v0.1.0.tar.gz"
 +  sha256 "..." # 以下のコマンドで取得したハッシュ値を記述
 +  version "0.1.0"
--  head "https://github.com/your-vendor/greet.git", branch: "main"
+   head "https://github.com/your-vendor/greet.git", branch: "main"
    
    depends_on "php@8.1"
    depends_on "composer"


### PR DESCRIPTION
Updated the CLI manual to mention that BEAR.Cli now generates Homebrew formulae along with commands. This addition explains how the generated formulae automate the installation of required dependencies for BEAR.Sunday applications, enabling users to quickly and easily start using the tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- CLIツールの使用および配布に関するドキュメントが更新され、インストール手順や出力形式の制御についての詳細が追加されました。
	- Homebrewフォーミュラの生成に関する具体的な指示が強化され、リポジトリ名との対応関係が明確化されました。

- **ドキュメンテーション**
	- CLIコマンドの使用例が拡充され、ヘルプ表示やバージョン情報の確認、JSON形式での出力オプションについて詳述されました。
	- エラーメッセージやHTTPステータスコードのマッピングに関する説明が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->