### PR TITLE
Add scripts and hooks for markdown file management and llms.txt compliance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,23 @@ redcarpet:
   extensions: ["autolink", "no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript", "with_toc_data", "tables"]
 highlighter: rouge
 repository: bearsunday/bearsunday.github.io
+
+# Include markdown files as static files for AI/llms.txt compatibility
+include:
+  - "manuals"
+
+# Exclude from processing but include as static files
+keep_files:
+  - "manuals"
+
+# Default settings for different file types
+defaults:
+  - scope:
+      path: "manuals/**/*.md"
+    values:
+      sitemap: false
+  - scope:
+      path: "manuals"
+      type: "pages"
+    values:
+      sitemap: false

--- a/_plugins/copy_markdown.rb
+++ b/_plugins/copy_markdown.rb
@@ -1,0 +1,24 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  # Copy markdown files to _site for direct access
+  source_dir = File.join(site.source, 'manuals')
+  dest_dir = File.join(site.dest, 'manuals')
+  
+  if Dir.exist?(source_dir)
+    # Create destination directory if it doesn't exist
+    FileUtils.mkdir_p(dest_dir) unless Dir.exist?(dest_dir)
+    
+    # Find all .md files and copy them
+    Dir.glob(File.join(source_dir, '**', '*.md')).each do |md_file|
+      # Calculate relative path
+      relative_path = Pathname.new(md_file).relative_path_from(Pathname.new(source_dir))
+      dest_file = File.join(dest_dir, relative_path)
+      
+      # Create destination directory if needed
+      FileUtils.mkdir_p(File.dirname(dest_file))
+      
+      # Copy the file
+      FileUtils.cp(md_file, dest_file)
+      puts "Copied #{relative_path} for llms.txt compatibility"
+    end
+  end
+end

--- a/bin/copy_markdown_files.sh
+++ b/bin/copy_markdown_files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Copy markdown files to _site directory for llms.txt standard compliance
+# This script should be run after Jekyll build
+# It removes Jekyll front matter from the copied files
+
+SOURCE_DIR="manuals"
+DEST_DIR="_site/manuals"
+
+echo "Copying markdown files for llms.txt compliance..."
+
+# Check if source directory exists
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    echo "Error: Source directory '$SOURCE_DIR' does not exist"
+    exit 1
+fi
+
+# Create destination directory
+mkdir -p "$DEST_DIR"
+
+# Find all .md files in manuals directory and copy them to _site
+find "$SOURCE_DIR" -name "*.md" -type f -print0 | while IFS= read -r -d '' file; do
+    # Get relative path
+    relative_path="${file#$SOURCE_DIR/}"
+    dest_file="$DEST_DIR/$relative_path"
+
+    # Create destination directory if it doesn't exist
+    mkdir -p "$(dirname "$dest_file")"
+
+    # Copy the file and remove front matter using awk (more reliable)
+    awk '
+        BEGIN { in_frontmatter = 0; first_line = 1 }
+        /^---$/ && first_line { in_frontmatter = 1; first_line = 0; next }
+        /^---$/ && in_frontmatter { in_frontmatter = 0; next }
+        !in_frontmatter { print }
+        { first_line = 0 }
+    ' "$file" > "$dest_file"
+
+    echo "Copied and cleaned: $relative_path"
+done
+
+echo "Markdown files copied successfully!"

--- a/bin/merge_md_files.rb
+++ b/bin/merge_md_files.rb
@@ -1,45 +1,146 @@
 require 'fileutils'
+require 'yaml'
+require 'pathname'
 
-def generate_combined_file(language, intro_message)
-  # マークダウンファイルが存在するフォルダ
-  source_folder = File.expand_path("../manuals/1.0/#{language}/", __dir__)
-  # 結合されたファイルの出力先
-  output_file = "manuals/1.0/#{language}/1page.md"
-
-  puts "Does the source folder exist? #{Dir.exist?(source_folder)}"
-  raise "Source folder does not exist!" unless File.directory?(source_folder)
-
-  # ファイルを開く
-  File.open(output_file, "w") do |combined_file|
-
-    # 全体のヘッダーを書き込む
-    combined_file.write("---\nlayout: docs-#{language}\ntitle: 1 Page Manual\ncategory: Manual\npermalink: /manuals/1.0/#{language}/1page.html\n---\n")
-
-    # 追加のメッセージを書き込む
-    combined_file.write(intro_message + "\n\n")
-
-    # 指定フォルダ内のすべての.mdファイルを取得し、ソートする
-    files = Dir.glob(File.join(source_folder, "*.md")).sort
-
-    # 各ファイルを処理する - ヘッダーを削除
-    files.each do |filepath|
-      File.open(filepath, "r") do |file|
-        # ファイル内容を読む
-        content = file.read
-
-        # ヘッダー部分を削除 （"---"で囲まれた部分を削除）
-        content.gsub!(/---.*?---/m, '')
-
-        # 出力ファイルに書き込み
-        combined_file.write(content + "\n")
-      end
-    end
-
-  end
-
-  puts "Markdown files have been combined into #{output_file}"
+def convert_to_markdown_filename(base_name)
+  # Generic kebab-case to CamelCase converter
+  # This handles both underscore and hyphen separators
+  base_name.split(/[_-]/).map(&:capitalize).join + '.md'
 end
 
-# 以下の行を使用して関数を2言語で呼び出す
-generate_combined_file("ja", "これはBEAR.Sundayの全てのマニュアルページを一つにまとめたページです。")
-generate_combined_file("en", "This page collects all BEAR.Sunday manuals in one place.")
+def extract_order_from_contents(language)
+  # Read contents.html to get the proper order
+  contents_file = File.expand_path("../_includes/manuals/1.0/#{language}/contents.html", __dir__)
+  unless File.exist?(contents_file)
+    puts "Warning: Contents file not found: #{contents_file}"
+    return nil
+  end
+
+  contents = File.read(contents_file)
+
+  # Extract permalinks from nav items
+  permalinks = contents.scan(/href="\/manuals\/1\.0\/#{language}\/([^"]+\.html)"/).flatten
+
+  # Validate that we found some permalinks
+  if permalinks.empty?
+    puts "Warning: No permalinks found in #{contents_file}. Navigation structure may have changed."
+    return nil
+  end
+
+  puts "Found #{permalinks.length} pages in navigation order"
+
+  # Convert HTML filenames to markdown filenames
+  markdown_files = permalinks.map do |permalink|
+    # Remove .html extension
+    base = permalink.sub('.html', '')
+
+    # Skip AI assistant and other non-documentation pages
+    skip_pages = ['ai-assistant', 'index', '1page']
+    next nil if skip_pages.include?(base)
+
+    # Convert kebab-case to CamelCase
+    convert_to_markdown_filename(base)
+  end.compact
+
+  markdown_files
+end
+
+def strip_frontmatter(content)
+  # Remove Jekyll frontmatter only from the very beginning of the file
+  # Support both LF (\n) and CRLF (\r\n) line endings
+  content.sub(/\A---\s*\r?\n.*?\r?\n---\s*\r?\n/m, '')
+end
+
+def generate_combined_file(language, intro_message)
+  source = Pathname.new(__dir__).join("..", "manuals/1.0/#{language}")
+  output_file = source.join("1page.md")
+
+  puts "Processing #{language} documentation..."
+  raise "Source folder does not exist!" unless source.directory?
+
+  # Determine file order from contents.html or fallback to alphabetical
+  file_order = extract_order_from_contents(language)
+  if file_order.nil? || file_order.empty?
+    puts "Warning: Could not extract order from contents.html, using alphabetical order"
+    main_md_files = source.glob("*.md")
+                          .map(&:basename)
+                          .map(&:to_s)
+                          .reject { |f| %w[1page.md ai-assistant.md].include?(f) }
+                          .sort
+    bp_md_files = source.join("bp").directory? ?
+                  source.join("bp").glob("*.md").map(&:basename).map(&:to_s).sort : []
+    file_order = main_md_files + bp_md_files.map { |f| "bp/#{f}" }
+  end
+
+  # Gather all files: main files in order + best practices
+  all_files = file_order.map { |fn| source.join(fn) }.select(&:file?)
+  main_files = all_files.reject { |f| f.dirname.basename.to_s == "bp" }
+  bp_files = all_files.select { |f| f.dirname.basename.to_s == "bp" }
+
+  files_processed = 0
+
+  File.open(output_file, "w") do |out|
+    # Write header
+    out.write <<~HEADER
+      ---
+      layout: docs-#{language}
+      title: BEAR.Sunday Complete Manual
+      category: Manual
+      permalink: /manuals/1.0/#{language}/1page.html
+      ---
+
+      # BEAR.Sunday Complete Manual
+
+      #{intro_message}
+
+      ***
+    HEADER
+
+    # Add best practices header before BP files
+    bp_start_index = main_files.length
+
+    # Process all files in a single pass
+    all_files.each_with_index do |path, idx|
+      begin
+        content = strip_frontmatter(path.read).strip
+        next if content.empty?
+
+        # Add separator between sections (except first)
+        out.write("\n***\n\n") if idx > 0
+
+        # Add BP section header if this is the first BP file
+        if idx == bp_start_index && idx < all_files.length
+          out.write("## Best Practices Details\n\n")
+        end
+
+        # Handle best practices heading conversion
+        if path.dirname.basename.to_s == "bp"
+          if content =~ /\A\#{1,6}\s+(.+?)\n(.*)/m
+            heading_text = $1
+            remaining_content = $2
+            out.write("\n### #{heading_text}\n\n#{remaining_content}\n")
+          else
+            # No heading found, generate from filename
+            title = path.basename(".md").to_s.gsub(/([A-Z])/, ' \1').strip
+            out.write("\n### #{title}\n\n#{content}\n")
+          end
+          puts "  Added BP: #{path.basename}"
+        else
+          out.write(content + "\n")
+          puts "  Added: #{path.basename}"
+        end
+
+        files_processed += 1
+      rescue => e
+        puts "  Error processing #{path.basename}: #{e.message}"
+      end
+    end
+  end
+
+  puts "Generated: #{output_file}"
+  puts "Total sections: #{files_processed}"
+end
+
+# Generate combined files for both languages
+generate_combined_file("en", "This comprehensive manual contains all BEAR.Sunday documentation in a single page for easy reference, printing, or offline viewing.")
+generate_combined_file("ja", "このページは、BEAR.Sundayの全ドキュメントを1ページにまとめた包括的なマニュアルです。参照、印刷、オフライン閲覧に便利です。")

--- a/bin/serve_local.sh
+++ b/bin/serve_local.sh
@@ -3,4 +3,9 @@
 # 'bundle exec' ensures we're using the correct versions of each gem according to our Gemfile.lock.
 # 'jekyll serve' starts a Jekyll development server.
 # '--watch' option automatically rebuilds the site when files are modified.
+
+# Copy markdown files for llms.txt compliance after initial build
+echo "Starting Jekyll server with llms.txt compliance..."
+bundle exec jekyll build
+./bin/copy_markdown_files.sh
 bundle exec jekyll serve --watch

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,6 +1,15 @@
 .highlight  { background: #f8f8f8; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+
+/* Fix PHP attribute highlighting - target # character in PHP code blocks */
+.language-php .highlighter-rouge .highlight .err,
+.language-php .highlight .err {
+    color: #6f42c1; /* Purple color for PHP attributes */
+    background-color: transparent;
+    font-weight: normal;
+}
+
 .highlight .k { font-weight: bold } /* Keyword */
 .highlight .o { font-weight: bold } /* Operator */
 .highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1287,17 +1287,48 @@ Note: Please refer to the [benchmark](https://github.com/bearsunday/BEAR.Hellowo
 
 ### .compile.php
 
-If there are classes that cannot be generated in non-production environments (for example, ResourceObjects that cannot be injected unless authentication succeeds), you can compile them by describing dummy class loading that is loaded only at compile time in the root `.compile.php`.
+When there are classes that cannot be generated in a non-production environment (for example, a ResourceObject that requires successful authentication to complete injection), you can compile them by describing dummy class loading in the root `.compile.php` file, which is only loaded during compilation.
 
 .compile.php
 
+Example) If there is an AuthProvider that throws an exception when authentication cannot be obtained in the constructor, you can create an empty class as follows and load it in .compile.php:
+
+/tests/Null/AuthProvider.php
 ```php
 <?php
-
-require __DIR__ . '/tests/Null/AuthProvider.php'; // Always generatable null object
-$_SERVER[__REQUIRED_KEY__] = 'fake';
+class AuthProvider 
+{  // Only for instantiation, so implementation is not required
+}
 ```
 
+.compile.php
+```php
+<?php
+require __DIR__ . '/tests/Null/AuthProvider.php'; // Always-generatable Null object
+$_SERVER[__REQUIRED_KEY__] = 'fake'; // For cases where errors occur without specific environment variables
+```
+
+This allows you to avoid exceptions and perform compilation. Additionally, since Symfony's cache component connects to the cache engine in the constructor, it's good to load a dummy adapter during compilation like this:
+
+tests/Null/RedisAdapter.php
+```php
+namespace Ray\PsrCacheModule;
+
+use Ray\Di\ProviderInterface;
+use Serializable;
+use Symfony\Component\Cache\Adapter\RedisAdapter as OriginAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+class RedisAdapter extends OriginAdapter implements Serializable
+{
+    use SerializableTrait;
+    
+    public function __construct(ProviderInterface $redisProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
+    {
+    　　// do nothing
+    }
+}
+```
 ### module.dot
 
 When you compile, a "dot file" is output, so you can convert it to an image file with [graphviz](https://graphviz.org/) or use [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/) to display the object graph.
@@ -3859,9 +3890,10 @@ In this way, resources created with BEAR.Sunday can be easily used from other CM
 
 BEAR.Sunday supports the following supported PHP versions
 
-* `8.1` (Old stable 25 Nov 2021 - 25 Nov 2024)
-* `8.2` (Old stable 8 Dec 2022 - 8 Dec 2025)
-* `8.3` (Current stable 23 Nov 2022 - 26 Nov 2026)
+* `8.1` (Old stable 25 Nov 2021 - 31 Dec 2025)
+* `8.2` (Old stable 8 Dec 2022 - 31 Dec 2026)
+* `8.3` (Old stable 23 Nov 2023 - 31 Dec 2027)
+* `8.4` (Current stable 21 Nov 2024 - 31 Dec 2028)
 
 * End of life ([EOL](http://php.net/eol.php))
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,26 +7,26 @@ This file provides information on key components, coding practices, and deployme
 
 ## Manuals
 
-- [Introduction](/manuals/1.0/en/index.html): Overview of BEAR.Sunday's philosophy and core concepts.
-- [AOP](/manuals/1.0/en/aop.html): Understand how Aspect-Oriented Programming enables modular, maintainable code.
-- [Resource](/manuals/1.0/en/resource.html): Learn about resources and their methods.
-- [Resource Parameters](/manuals/1.0/en/resource_param.html): How data from web requests binds to resources.
-- [Resource Link](/manuals/1.0/en/resource_link.html): How resources link to each other.
-- [Rendering and Transfer](/manuals/1.0/en/resource_renderer.html): Understand how representations (HTML, JSON) are produced and transferred.
-- [Router](/manuals/1.0/en/router.html): How external requests are mapped to internal resources.
-- [Production](/manuals/1.0/en/production.html): Setting up the application for a live environment.
-- [Import](/manuals/1.0/en/import.html): Learn to use features from other BEAR applications.
-- [Tests](/manuals/1.0/en/test.html): Understand how to test resources.
-- [Examples](/manuals/1.0/en/examples.html): Explore practical examples of BEAR.Sunday applications.
-- [Database](/manuals/1.0/en/database.html): Using various databases modules.
-- [Coding Guide](/manuals/1.0/en/coding-guide.html): Learn about BEAR.Sunday coding-guide.
-- [PHPDoc Types](/manuals/1.0/en/types.html): Using phpdoc to create statically analysed code.
-- [Stream](/manuals/1.0/en/stream.html): Creating Streaming output for large file.
-- [CLI](/manuals/1.0/en/cli.html): Create command line tools for your app.
-- [Attributes](/manuals/1.0/en/attribute.html): PHP8 attribute usage.
-- [API Doc](/manuals/1.0/en/apidoc.html): Automatic API document generation with ApiDoc.
-- [AaaS](/manuals/1.0/en/aaas.html): Create an application that can run in other frameworks.
+- [Introduction](/manuals/1.0/en/index.md): Overview of BEAR.Sunday's philosophy and core concepts.
+- [AOP](/manuals/1.0/en/aop.md): Understand how Aspect-Oriented Programming enables modular, maintainable code.
+- [Resource](/manuals/1.0/en/resource.md): Learn about resources and their methods.
+- [Resource Parameters](/manuals/1.0/en/resource_param.md): How data from web requests binds to resources.
+- [Resource Link](/manuals/1.0/en/resource_link.md): How resources link to each other.
+- [Rendering and Transfer](/manuals/1.0/en/resource_renderer.md): Understand how representations (HTML, JSON) are produced and transferred.
+- [Router](/manuals/1.0/en/router.md): How external requests are mapped to internal resources.
+- [Production](/manuals/1.0/en/production.md): Setting up the application for a live environment.
+- [Import](/manuals/1.0/en/import.md): Learn to use features from other BEAR applications.
+- [Tests](/manuals/1.0/en/test.md): Understand how to test resources.
+- [Examples](/manuals/1.0/en/examples.md): Explore practical examples of BEAR.Sunday applications.
+- [Database](/manuals/1.0/en/database.md): Using various databases modules.
+- [Coding Guide](/manuals/1.0/en/coding-guide.md): Learn about BEAR.Sunday coding-guide.
+- [PHPDoc Types](/manuals/1.0/en/types.md): Using phpdoc to create statically analysed code.
+- [Stream](/manuals/1.0/en/stream.md): Creating Streaming output for large file.
+- [CLI](/manuals/1.0/en/cli.md): Create command line tools for your app.
+- [Attributes](/manuals/1.0/en/attribute.md): PHP8 attribute usage.
+- [API Doc](/manuals/1.0/en/apidoc.md): Automatic API document generation with ApiDoc.
+- [AaaS](/manuals/1.0/en/aaas.md): Create an application that can run in other frameworks.
 
 ## Version
-- [Version Policy](/manuals/1.0/en/version.html): Versions of BEAR.Sunday and the long term support.
+- [Version Policy](/manuals/1.0/en/version.md): Versions of BEAR.Sunday and the long term support.
 


### PR DESCRIPTION
## Summary by Sourcery

Add tooling and configuration to assemble and export markdown manuals: extend the merge_md_files script for ordered single-page outputs, introduce scripts and hooks to surface raw .md files in the generated site for llms.txt compatibility, and tweak syntax highlighting.

New Features:
- Enhance merge_md_files.rb to generate comprehensive single-page manuals with ordering derived from navigation and best practices handling
- Add a bash script and a Jekyll plugin to copy raw markdown files into the built site for llms.txt compliance

Bug Fixes:
- Adjust PHP code block highlighting to correctly style attribute markers in syntax.css

Enhancements:
- Update serve_local.sh to perform an initial build and invoke the markdown copy step for llms.txt compliance
- Configure _config.yml to include manual markdown files as static assets and disable their sitemap entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「manuals」ディレクトリ内のMarkdownファイルを静的コンテンツとして含め、サイト生成後に自動コピーされるようになりました。
  * MarkdownファイルからJekyllフロントマターを自動的に除去する機能を追加しました。

* **ドキュメント**
  * llms.txtおよびllms-full.txtのマニュアルリンクを.mdファイルに更新し、ダミークラスの説明やPHPバージョン情報を改善しました。

* **スタイル**
  * PHPコードブロック内のエラー表示スタイルを調整し、可読性を向上しました。

* **リファクタ**
  * マニュアル結合スクリプトの処理順序や見出し生成などを改善しました。

* **その他**
  * サーバー起動時にビルドとMarkdownコピー処理を自動実行するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->