### PR TITLE
Add security documentation page

### DIFF
--- a/_includes/manuals/1.0/en/contents.html
+++ b/_includes/manuals/1.0/en/contents.html
@@ -129,6 +129,9 @@
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/en/test.html' %}active{% endif %}" href="/manuals/1.0/en/test.html">Test</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link {% if page.permalink == '/manuals/1.0/en/security.html' %}active{% endif %}" href="/manuals/1.0/en/security.html">Security</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/en/examples.html' %}active{% endif %}" href="/manuals/1.0/en/examples.html">Examples</a>
             </li>
             <li class="nav-item">

--- a/_includes/manuals/1.0/ja/contents.html
+++ b/_includes/manuals/1.0/ja/contents.html
@@ -128,6 +128,9 @@
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/test.html' %}active{% endif %}" href="/manuals/1.0/ja/test.html">テスト</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/security.html' %}active{% endif %}" href="/manuals/1.0/ja/security.html">セキュリティ</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link {% if page.permalink == '/manuals/1.0/ja/examples.html' %}active{% endif %}" href="/manuals/1.0/ja/examples.html">サンプル</a>
             </li>
             <li class="nav-item">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1913,7 +1913,7 @@ Tests include:
 |------|---------------|
 | SQL Injection | `' OR '1'='1`, `; DROP TABLE` |
 | XSS | `<script>alert(1)</script>` |
-| Command Injection | `; ls -la`, `| cat /etc/passwd` |
+| Command Injection | `; ls -la`, `\| cat /etc/passwd` |
 | Path Traversal | `../../../etc/passwd` |
 | Security Headers | Checks for missing headers |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -345,9 +345,11 @@ The version of the framework does not lock the version of the library. The libra
 Installation is done via [composer](http://getcomposer.org)
 
 ```bash
-composer create-project -n bear/skeleton MyVendor.MyProject
-cd MyVendor.MyProject
+VENDOR=MyVendor PACKAGE=MyProject composer create-project bear/skeleton my-project
+cd my-project
 ```
+
+Use `VENDOR` to specify the vendor name and `PACKAGE` to specify the package name for installation. If not specified, you will be prompted interactively.
 
 Next, let's create a new resource. A resource is a class which corresponds, for instance, to a JSON payload (if working with an API-first driven model) 
 or a web page.
@@ -1859,6 +1861,115 @@ Reference
 
 
 
+# Security
+
+The [bear/security](https://github.com/bearsunday/BEAR.Security) package helps find security vulnerabilities in your BEAR.Sunday application.
+
+## Installation
+
+```bash
+composer require --dev bear/security
+```
+
+## Scanning Tools
+
+| Tool | What it does | When to use |
+|------|--------------|-------------|
+| SAST | Finds dangerous patterns in your code | During development |
+| DAST | Sends attack requests to your app | Before deployment |
+| AI Auditor | AI reviews your code for security issues | Code review |
+| Psalm Plugin | Traces user input to dangerous operations | During development |
+
+## SAST
+
+Scans your source code for dangerous patterns:
+
+```bash
+./vendor/bin/bear.security-scan src
+```
+
+Detects 14 vulnerability types:
+
+| Category | Examples |
+|----------|----------|
+| Injection | SQL injection, Command injection, XSS |
+| Access Control | Path traversal, Open redirect |
+| Cryptography | Weak hash algorithms, Hardcoded secrets |
+| Data Protection | Insecure deserialization, XXE |
+| Session | Session fixation, CSRF |
+| Network | SSRF, Remote file inclusion |
+
+## DAST
+
+Sends attack payloads to your running application to test real vulnerabilities:
+
+```bash
+./vendor/bin/bear-security-dast 'MyVendor\MyApp' prod-app /path/to/app
+```
+
+Tests include:
+
+| Test | What it sends |
+|------|---------------|
+| SQL Injection | `' OR '1'='1`, `; DROP TABLE` |
+| XSS | `<script>alert(1)</script>` |
+| Command Injection | `; ls -la`, `| cat /etc/passwd` |
+| Path Traversal | `../../../etc/passwd` |
+| Security Headers | Checks for missing headers |
+
+## AI Auditor
+
+Uses Claude AI to find security issues that pattern matching cannot detect:
+
+```bash
+# Requires ANTHROPIC_API_KEY or Claude CLI authentication
+./vendor/bin/bear-security-audit src
+```
+
+| Issue | Description |
+|-------|-------------|
+| IDOR | Accessing other users' data without authorization check |
+| Mass Assignment | Accepting unvalidated fields in updates |
+| Race Condition | Time-of-check to time-of-use flaws |
+| Business Logic | Application-specific security flaws |
+
+## Psalm Plugin
+
+Traces how user input (like `$id` in `onGet($id)`) flows through your code. Reports when it reaches dangerous operations like database queries without proper escaping:
+
+```bash
+./vendor/bin/psalm --taint-analysis
+```
+
+## GitHub Actions
+
+Add security scanning to your CI pipeline:
+
+```bash
+cp vendor/bear/security/workflows/security-sast.yml .github/workflows/
+```
+
+This workflow runs on every push and pull request:
+
+| Job | What it does |
+|-----|--------------|
+| SAST Scan | Scans code and uploads results to GitHub Security tab |
+| Psalm Taint | Traces user input flows and uploads results to GitHub Security tab |
+
+Results appear in your repository's **Security > Code scanning** section.
+
+## Why It Works
+
+BEAR.Sunday's architecture makes security scanning more effective:
+
+- **Clear Entry Points**: Every endpoint is a ResourceObject with `onGet`, `onPost` methods. Scanners can identify all inputs and trace data flow.
+
+- **No Hidden Magic**: Dependencies are explicit through constructor injection. Scanners can analyze the complete code path.
+
+- **Framework-Aware AI**: The AI Auditor understands BEAR.Sunday patterns and can detect business logic flaws, not just generic vulnerabilities.
+
+
+
 # Reference
 
 ## Attributes
@@ -2377,10 +2488,10 @@ In this tutorial, we introduce the basic features of BEAR.Sunday, including **DI
 Let's create a web service that returns the day of the week when a date (year, month, day) is entered. Start by creating a project.
 
 ```bash
-composer create-project bear/skeleton MyVendor.Weekday
+VENDOR=MyVendor PACKAGE=Weekday composer create-project bear/skeleton weekday
+cd weekday
 ```
-
-Enter `MyVendor` for the **vendor** name and `Weekday` for the **project** name. [^2]
+[^2]
 
 ## Resources
 
@@ -3483,11 +3594,10 @@ Let's proceed with the commits found in [tutorial2](https://github.com/bearsunda
 
 Create the project skeleton.
 
+```bash
+VENDOR=MyVendor PACKAGE=Ticket composer create-project bear/skeleton ticket
+cd ticket
 ```
-composer create-project bear/skeleton MyVendor.Ticket
-```
-
-Enter the **vendor** name as `MyVendor` and the **project** name as `Ticket`.
 
 ## Migration
 
@@ -4371,8 +4481,8 @@ The comment is not only descriptive, but also makes it easier to identify the SQ
 ### 1.1 Create a New Project
 
 ```bash
-composer create-project -n bear/skeleton MyVendor.Greet
-cd MyVendor.Greet
+VENDOR=MyVendor PACKAGE=Greet composer create-project bear/skeleton greet
+cd greet
 ```
 
 ### 1.2 Verify Development Server
@@ -6199,7 +6309,7 @@ At this time `JaModule` requires binding for Japanese text. For details, refer t
 
 ## Enable by Resource
 
-To do content negotiation on a resource basis, install the `AcceptModule` module and use the `@Produces` annotation.
+To do content negotiation on a resource basis, install the `AcceptModule` module and use the `#[Produces]` attribute.
 
 ### Module Install
 
@@ -6212,18 +6322,16 @@ protected function configure()
 }
 ```
 
-## @Produces annotation
+## #[Produces] Attribute
 
 ```php?start_inline
-use BEAR\Accept\Annotation\Produces;
+use BEAR\Accept\Attribute\Produces;
 
-/**
- * @Produces({"application/hal+json", "text/csv"})
- */
+#[Produces(['application/hal+json', 'text/csv'])]
 public function onGet()
 ```
 
-Annotate available media type from left by priority. The representation (JSON or HTML) is changed by the contextual renderer. You do not need to add `Vary` header manually unlike application level content-negotiation.
+Specify available media types from left by priority. The representation (JSON or HTML) is changed by the contextual renderer. You do not need to add `Vary` header manually unlike application level content-negotiation.
 
 ## Access using curl
 
@@ -6785,6 +6893,36 @@ $this->headers[Header::SURROGATE_KEY] = $this->uriTag->fromAssoc(
 ```
 
 In the above case, this cache will be invalidated for both server-side and CDN when `app://self/item?id=1` and `app://self/item?id=2` are changed.
+
+## Configuration
+
+### Redis Marshaller
+
+The Redis cache adapter allows you to configure data compression and serialization methods.
+
+A marshaller handles the serialization of PHP objects and arrays when storing them in Redis, and deserialization when retrieving them.
+
+```php
+use BEAR\QueryRepository\StorageRedisDsnModule;
+
+$this->install(
+    new StorageRedisDsnModule(
+        dsn: 'redis://localhost:6379',
+        marshallingOptions: [
+            'enabled' => true,
+            'type' => 'deflate',      // 'default' or 'deflate'
+            'use_igbinary' => true    // requires ext-igbinary
+        ]
+    )
+);
+```
+
+**Marshaller types:**
+
+- `default`: Uses PHP's standard serialization (enabling `use_igbinary` uses a more efficient binary format)
+- `deflate`: Compresses data before storing (uses zlib)
+
+Use `deflate` if you want to reduce Redis memory usage. This is a trade-off with CPU usage.
 
 ## CDN
 

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@
 - [Router](/manuals/1.0/en/router.md): Request routing to resources
 - [Production](/manuals/1.0/en/production.md): Deployment and optimization
 - [Test](/manuals/1.0/en/test.md): Testing resources
+- [Security](/manuals/1.0/en/security.md): Security scanning (SAST, DAST, AI Auditor)
 - [Reference](/manuals/1.0/en/reference.md): Attributes and modules reference
 
 ## Optional

--- a/manuals/1.0/en/security.md
+++ b/manuals/1.0/en/security.md
@@ -57,7 +57,7 @@ Tests include:
 |------|---------------|
 | SQL Injection | `' OR '1'='1`, `; DROP TABLE` |
 | XSS | `<script>alert(1)</script>` |
-| Command Injection | `; ls -la`, `| cat /etc/passwd` |
+| Command Injection | `; ls -la`, `\| cat /etc/passwd` |
 | Path Traversal | `../../../etc/passwd` |
 | Security Headers | Checks for missing headers |
 

--- a/manuals/1.0/en/security.md
+++ b/manuals/1.0/en/security.md
@@ -1,0 +1,113 @@
+---
+layout: docs-en
+title: Security
+category: Manual
+permalink: /manuals/1.0/en/security.html
+---
+
+# Security
+
+The [bear/security](https://github.com/bearsunday/BEAR.Security) package helps find security vulnerabilities in your BEAR.Sunday application.
+
+## Installation
+
+```bash
+composer require --dev bear/security
+```
+
+## Scanning Tools
+
+| Tool | What it does | When to use |
+|------|--------------|-------------|
+| SAST | Finds dangerous patterns in your code | During development |
+| DAST | Sends attack requests to your app | Before deployment |
+| AI Auditor | AI reviews your code for security issues | Code review |
+| Psalm Plugin | Traces user input to dangerous operations | During development |
+
+## SAST
+
+Scans your source code for dangerous patterns:
+
+```bash
+./vendor/bin/bear.security-scan src
+```
+
+Detects 14 vulnerability types:
+
+| Category | Examples |
+|----------|----------|
+| Injection | SQL injection, Command injection, XSS |
+| Access Control | Path traversal, Open redirect |
+| Cryptography | Weak hash algorithms, Hardcoded secrets |
+| Data Protection | Insecure deserialization, XXE |
+| Session | Session fixation, CSRF |
+| Network | SSRF, Remote file inclusion |
+
+## DAST
+
+Sends attack payloads to your running application to test real vulnerabilities:
+
+```bash
+./vendor/bin/bear-security-dast 'MyVendor\MyApp' prod-app /path/to/app
+```
+
+Tests include:
+
+| Test | What it sends |
+|------|---------------|
+| SQL Injection | `' OR '1'='1`, `; DROP TABLE` |
+| XSS | `<script>alert(1)</script>` |
+| Command Injection | `; ls -la`, `| cat /etc/passwd` |
+| Path Traversal | `../../../etc/passwd` |
+| Security Headers | Checks for missing headers |
+
+## AI Auditor
+
+Uses Claude AI to find security issues that pattern matching cannot detect:
+
+```bash
+# Requires ANTHROPIC_API_KEY or Claude CLI authentication
+./vendor/bin/bear-security-audit src
+```
+
+| Issue | Description |
+|-------|-------------|
+| IDOR | Accessing other users' data without authorization check |
+| Mass Assignment | Accepting unvalidated fields in updates |
+| Race Condition | Time-of-check to time-of-use flaws |
+| Business Logic | Application-specific security flaws |
+
+## Psalm Plugin
+
+Traces how user input (like `$id` in `onGet($id)`) flows through your code. Reports when it reaches dangerous operations like database queries without proper escaping:
+
+```bash
+./vendor/bin/psalm --taint-analysis
+```
+
+## GitHub Actions
+
+Add security scanning to your CI pipeline:
+
+```bash
+cp vendor/bear/security/workflows/security-sast.yml .github/workflows/
+```
+
+This workflow runs on every push and pull request:
+
+| Job | What it does |
+|-----|--------------|
+| SAST Scan | Scans code and uploads results to GitHub Security tab |
+| Psalm Taint | Traces user input flows and uploads results to GitHub Security tab |
+
+Results appear in your repository's **Security > Code scanning** section.
+
+## Why It Works
+
+BEAR.Sunday's architecture makes security scanning more effective:
+
+- **Clear Entry Points**: Every endpoint is a ResourceObject with `onGet`, `onPost` methods. Scanners can identify all inputs and trace data flow.
+
+- **No Hidden Magic**: Dependencies are explicit through constructor injection. Scanners can analyze the complete code path.
+
+- **Framework-Aware AI**: The AI Auditor understands BEAR.Sunday patterns and can detect business logic flaws, not just generic vulnerabilities.

--- a/manuals/1.0/ja/security.md
+++ b/manuals/1.0/ja/security.md
@@ -57,7 +57,7 @@ composer require --dev bear/security
 |--------|----------|
 | SQLインジェクション | `' OR '1'='1`, `; DROP TABLE` |
 | XSS | `<script>alert(1)</script>` |
-| コマンドインジェクション | `; ls -la`, `| cat /etc/passwd` |
+| コマンドインジェクション | `; ls -la`, `\| cat /etc/passwd` |
 | パストラバーサル | `../../../etc/passwd` |
 | セキュリティヘッダー | 欠落ヘッダーのチェック |
 

--- a/manuals/1.0/ja/security.md
+++ b/manuals/1.0/ja/security.md
@@ -1,0 +1,113 @@
+---
+layout: docs-ja
+title: セキュリティ
+category: Manual
+permalink: /manuals/1.0/ja/security.html
+---
+
+# セキュリティ
+
+[bear/security](https://github.com/bearsunday/BEAR.Security)パッケージは、BEAR.Sundayアプリケーションのセキュリティ脆弱性を検出します。
+
+## インストール
+
+```bash
+composer require --dev bear/security
+```
+
+## スキャンツール
+
+| ツール | 機能 | 使用タイミング |
+|--------|------|----------------|
+| SAST | コード内の危険なパターンを検出 | 開発中 |
+| DAST | アプリに攻撃リクエストを送信 | デプロイ前 |
+| AI Auditor | AIがコードをレビュー | コードレビュー時 |
+| Psalm Plugin | ユーザー入力の流れを追跡 | 開発中 |
+
+## SAST
+
+ソースコードをスキャンして危険なパターンを検出します：
+
+```bash
+./vendor/bin/bear.security-scan src
+```
+
+14種類の脆弱性を検出：
+
+| カテゴリ | 例 |
+|----------|-----|
+| インジェクション | SQLインジェクション、コマンドインジェクション、XSS |
+| アクセス制御 | パストラバーサル、オープンリダイレクト |
+| 暗号 | 弱いハッシュアルゴリズム、ハードコードされた秘密鍵 |
+| データ保護 | 安全でないデシリアライゼーション、XXE |
+| セッション | セッション固定、CSRF |
+| ネットワーク | SSRF、リモートファイルインクルージョン |
+
+## DAST
+
+実行中のアプリケーションに攻撃ペイロードを送信して脆弱性をテストします：
+
+```bash
+./vendor/bin/bear-security-dast 'MyVendor\MyApp' prod-app /path/to/app
+```
+
+テスト内容：
+
+| テスト | 送信内容 |
+|--------|----------|
+| SQLインジェクション | `' OR '1'='1`, `; DROP TABLE` |
+| XSS | `<script>alert(1)</script>` |
+| コマンドインジェクション | `; ls -la`, `| cat /etc/passwd` |
+| パストラバーサル | `../../../etc/passwd` |
+| セキュリティヘッダー | 欠落ヘッダーのチェック |
+
+## AI Auditor
+
+パターンマッチングでは検出できないセキュリティ問題をClaude AIが検出します：
+
+```bash
+# ANTHROPIC_API_KEY または Claude CLI認証が必要
+./vendor/bin/bear-security-audit src
+```
+
+| 問題 | 説明 |
+|------|------|
+| IDOR | 認可チェックなしで他ユーザーのデータにアクセス |
+| マスアサインメント | 未検証のフィールドを更新で受け入れ |
+| レースコンディション | チェック時と使用時の競合 |
+| ビジネスロジック | アプリケーション固有のセキュリティ欠陥 |
+
+## Psalm Plugin
+
+ユーザー入力（`onGet($id)`の`$id`など）がコード内をどう流れるかを追跡します。適切なエスケープなしでデータベースクエリに到達した場合に報告します：
+
+```bash
+./vendor/bin/psalm --taint-analysis
+```
+
+## GitHub Actions
+
+CIパイプラインにセキュリティスキャンを追加：
+
+```bash
+cp vendor/bear/security/workflows/security-sast.yml .github/workflows/
+```
+
+このワークフローはプッシュとプルリクエストごとに実行されます：
+
+| ジョブ | 機能 |
+|--------|------|
+| SAST Scan | コードをスキャンしてGitHub Securityタブに結果をアップロード |
+| Psalm Taint | ユーザー入力の流れを追跡してGitHub Securityタブに結果をアップロード |
+
+結果はリポジトリの **Security > Code scanning** セクションに表示されます。
+
+## なぜ効果的か
+
+BEAR.Sundayのアーキテクチャがセキュリティスキャンをより効果的にします：
+
+- **明確なエントリーポイント**: すべてのエンドポイントは`onGet`、`onPost`メソッドを持つResourceObjectです。スキャナーはすべての入力を特定してデータフローを追跡できます。
+
+- **隠れたマジックがない**: 依存関係はコンストラクタインジェクションで明示的です。スキャナーは完全なコードパスを解析できます。
+
+- **フレームワークを理解するAI**: AI AuditorはBEAR.Sundayのパターンを理解し、一般的な脆弱性だけでなくビジネスロジックの欠陥も検出できます。


### PR DESCRIPTION
Add security documentation for bear/security package.

- English: `/manuals/1.0/en/security.md`
- Japanese: `/manuals/1.0/ja/security.md`

Covers SAST, DAST, AI Auditor, Psalm Plugin, and GitHub Actions integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 英語・日本語で BEAR.Security 統合の新しいドキュメントを追加しました。インストール手順、SAST/DAST/AI Auditor/ Psalm プラグインなどのスキャン手順、テストペイロード例、GitHub Actions ワークフロー統合、およびセキュリティに関する考察を含みます。
* **Documentation**
  * マニュアルの目次に「Security／セキュリティ」項目を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->