### PR TITLE
Add SAST/DAST footnotes

### DIFF
--- a/manuals/1.0/en/security.md
+++ b/manuals/1.0/en/security.md
@@ -19,10 +19,13 @@ composer require --dev bear/security
 
 | Tool | What it does | When to use |
 |------|--------------|-------------|
-| SAST | Finds dangerous patterns in your code | During development |
-| DAST | Sends attack requests to your app | Before deployment |
+| SAST[^1] | Static analysis to find dangerous patterns in your code | During development |
+| DAST[^2] | Dynamic analysis to send attack requests to your app | Before deployment |
 | AI Auditor | AI reviews your code for security issues | Code review |
 | Psalm Plugin | Traces user input to dangerous operations | During development |
+
+[^1]: Static Application Security Testing
+[^2]: Dynamic Application Security Testing
 
 ## SAST
 

--- a/manuals/1.0/ja/security.md
+++ b/manuals/1.0/ja/security.md
@@ -19,10 +19,13 @@ composer require --dev bear/security
 
 | ツール | 機能 | 使用タイミング |
 |--------|------|----------------|
-| SAST | コード内の危険なパターンを検出 | 開発中 |
-| DAST | アプリに攻撃リクエストを送信 | デプロイ前 |
+| SAST[^1] | 静的解析でコード内の危険なパターンを検出 | 開発中 |
+| DAST[^2] | 動的解析でアプリに攻撃リクエストを送信 | デプロイ前 |
 | AI Auditor | AIがコードをレビュー | コードレビュー時 |
 | Psalm Plugin | ユーザー入力の流れを追跡 | 開発中 |
+
+[^1]: Static Application Security Testing
+[^2]: Dynamic Application Security Testing
 
 ## SAST
 


### PR DESCRIPTION
## Summary
- Add footnotes explaining SAST (Static Application Security Testing) and DAST (Dynamic Application Security Testing) terminology
- Update table descriptions to include "静的解析で" / "動的解析で" (static/dynamic analysis) for clarity

This helps readers who may not be familiar with these security testing acronyms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * セキュリティドキュメントが更新されました。スキャンツールの表の説明がより詳細になり、SAST と DAST の定義が脚注で明記されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->