### PR TITLE
Remove outdated references from js-ui documentation

### DIFF
--- a/manuals/1.0/en/js-ui.md
+++ b/manuals/1.0/en/js-ui.md
@@ -20,6 +20,7 @@ This module is suited for the following scenarios:
 - Rendering most pages with your existing template engine, while using JS UI only for pages requiring high interactivity
 - Adding React or Vue.js UI to specific pages in an existing BEAR.Sunday project
 - Maintaining a single PHP application without separating frontend and backend
+- Enabling PHP and JS teams to develop in parallel using `state/metas` as the contract
 
 Only resources with the `#[Ssr]` attribute are rendered with JS UI, allowing easy coexistence with traditional template engines.
 
@@ -27,14 +28,9 @@ Only resources with the `#[Ssr]` attribute are rendered with JS UI, allowing eas
 
 * PHP 8.2+
 * [Node.js](https://nodejs.org/)
-* [V8Js](http://php.net/manual/en/book.v8js.php) (Development option)
+* [V8Js](https://www.php.net/manual/en/book.v8js.php) (Development option)
 
 Note: If you do not install V8Js then JS will be run using Node.js.
-
-## Terminology
-
-* **CSR** Client Side Rendering (via Web Browser)
-* **SSR** Server Side Rendering (via V8 or Node.js)
 
 ## JavaScript
 
@@ -241,8 +237,7 @@ For other commands such `lint` or `test` etc. please see [commands](https://gith
 
 ## Performance
 
-The ability to save the V8 Snapshot into APC means we can see dramatic performance benefits. In `ProdModule` install `ApcSsrModule`.
-ReactJs or your application snapshot is saved in `APCu` and can be reused. V8 is required.
+The V8 snapshot can be saved to APCu for improved performance. Install `ApcSsrModule` in `ProdModule`. V8Js is required:
 
 ```php
 $bundleSrcBasePath = dirname(__DIR__, 2) . '/var/www/build';
@@ -251,39 +246,4 @@ $this->install(new ApcSsrModule($bundleSrcBasePath));
 
 The `$bundleSrcBasePath` is the directory path where the JavaScript bundle files are located.
 
-To use caches other than APC look at the code in `ApcSsrModule` as a reference to make your own module. It is possible to use a cache compatible with PSR16.
 
-In order to tune performance at compile time pulling in your JS code (and ReactJs etc) into the V8 snapshot can give you further performance improvements.
-For more info please see the following.
-
-* [20x performance boost with V8Js snapshots](http://stesie.github.io/2016/02/snapshot-performance)
-* [v8js - Possibility to Improve Performance with Precompiled Templates/Classes?](https://github.com/phpv8/v8js/issues/205)
-
-## Debugging
-
-* Chrome Plugin [React developer tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) or [Redux devTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) can be used.
-* When a 500 error is returned look at the response details by using `var/log` or `curl` etc.
-
-## References
-
-* [ECMAScript 6](http://postd.cc/es6-cheatsheet/)
-* [Airbnb JavaScript Styleguide](https://github.com/airbnb/javascript)
-* [React](https://facebook.github.io/react/)
-* [Redux](http://redux.js.org/)
-* [Redux GitHub](https://github.com/reactjs/redux)
-* [Redux DevTools](https://github.com/gaearon/redux-devtools)
-* [Karma test runner](http://karma-runner.github.io/1.0/index.html)
-* [Mocha test framework](https://mochajs.org/)
-* [Chai assertion library](http://chaijs.com/)
-* [Webpack module bundler](https://webpack.js.org/)
-
-## Other view libraries
-
-* [Vue.js](https://vuejs.org/)
-* [Handlebars.js](http://handlebarsjs.com/)
-* [doT.js](http://olado.github.io/doT/index.html)
-* [Pug](https://pugjs.org/api/getting-started.html)
-* [Hogan](http://twitter.github.io/hogan.js/) (Twitter)
-* [Nunjucks](https://mozilla.github.io/nunjucks/) (Mozilla)
-* [Dust.js](http://www.dustjs.com/) (LinkedIn)
-* [Marko](http://markojs.com/) (eBay)

--- a/manuals/1.0/ja/js-ui.md
+++ b/manuals/1.0/ja/js-ui.md
@@ -20,6 +20,7 @@ permalink: /manuals/1.0/ja/js-ui.html
 - 大部分のページは既存のテンプレートエンジンでレンダリングし、高度なインタラクティブ性が求められる一部のページのみJS UIを使いたい
 - 既存のBEAR.Sundayプロジェクトに、特定のページのみReactやVue.jsのUIを追加したい
 - フロントエンドとバックエンドを分離せず、単一のPHPアプリケーションとして運用したい
+- PHPチームとJSチームが`state/metas`を契約として並行開発したい
 
 `#[Ssr]`アトリビュートを付与したリソースのみがJS UIでレンダリングされるため、従来のテンプレートエンジンとの共存が容易です。
 
@@ -27,14 +28,9 @@ permalink: /manuals/1.0/ja/js-ui.html
 
 * PHP 8.2以上
 * [Node.js](https://nodejs.org/ja/)
-* [V8Js](http://php.net/manual/ja/book.v8js.php)（開発時はオプション）
+* [V8Js](https://www.php.net/manual/ja/book.v8js.php)（開発時はオプション）
 
 注：V8Jsがインストールされていない場合、Node.jsでJavaScriptが実行されます。
-
-## 用語
-
-* **CSR**: クライアントサイドレンダリング（Webブラウザで描画）
-* **SSR**: サーバーサイドレンダリング（サーバーサイドのV8またはNode.jsが描画）
 
 ## JavaScript
 
@@ -239,7 +235,7 @@ npm run dev
 
 ## パフォーマンス
 
-V8のスナップショットをAPCuに保存する機能を使って、パフォーマンスの大幅な向上が可能です。`ProdModule`で`ApcSsrModule`をインストールしてください。Reactやアプリケーションのスナップショットが`APCu`に保存され再利用されます。V8Jsが必要です：
+V8のスナップショットをAPCuに保存する機能を使って、パフォーマンスの向上が可能です。`ProdModule`で`ApcSsrModule`をインストールしてください。V8Jsが必要です：
 
 ```php
 $bundleSrcBasePath = dirname(__DIR__, 2) . '/var/www/build';
@@ -247,41 +243,3 @@ $this->install(new ApcSsrModule($bundleSrcBasePath));
 ```
 
 `$bundleSrcBasePath`はJavaScriptバンドルファイルがあるディレクトリのパスです。
-
-APCu以外のキャッシュを利用するには、`ApcSsrModule`のコードを参考にモジュールを作成してください。PSR-16対応のキャッシュが利用可能です。
-
-さらなる高速化のためには、V8をコンパイルする時点でJavaScriptコード（Reactなど）のスナップショットを取り込みます。詳しくは以下をご覧ください：
-
-* [20x performance boost with V8Js snapshots](http://stesie.github.io/2016/02/snapshot-performance)
-* [v8js - Possibility to Improve Performance with Precompiled Templates/Classes?](https://github.com/phpv8/v8js/issues/205)
-
-## デバッグ
-
-* Chromeプラグイン[React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)、[Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)が利用できます。
-* 500エラーが返ってくる場合は、`var/log`や`curl`でアクセスしてレスポンスの詳細を確認してみましょう。
-
-## リファレンス
-
-* [ECMAScript 6](http://postd.cc/es6-cheatsheet/)
-* [Airbnb JavaScript スタイルガイド](http://mitsuruog.github.io/javascript-style-guide/)
-* [React](https://facebook.github.io/react/)
-* [Redux](http://redux.js.org/)
-* [Redux GitHub](https://github.com/reactjs/redux)
-* [Redux DevTools](https://github.com/gaearon/redux-devtools)
-* [Karma テストランナー](http://karma-runner.github.io/1.0/index.html)
-* [Mocha テストフレームワーク](https://mochajs.org/)
-* [Chai アサーションライブラリ](http://chaijs.com/)
-* [Webpack モジュールバンドラー](https://webpack.js.org/)
-
-## その他ビューライブラリ
-
-* [Vue.js](https://jp.vuejs.org/)
-* [Handlebars.js](http://handlebarsjs.com/)
-* [doT.js](http://olado.github.io/doT/index.html)
-* [Pug](https://pugjs.org/api/getting-started.html)
-* [Hogan](http://twitter.github.io/hogan.js/)（Twitter）
-* [Nunjucks](https://mozilla.github.io/nunjucks/)（Mozilla）
-* [Dust.js](http://www.dustjs.com/)（LinkedIn）
-* [Marko](http://markojs.com/)（eBay）
-
-*以前のReact JSページは[ReactJs](reactjs.html)をご覧ください。*


### PR DESCRIPTION
## Summary

Remove outdated references and simplify content in JavaScript UI documentation.

## Changes

- Remove "References" section (outdated links to 2015-2016 articles)
- Remove "Other view libraries" section (many deprecated libraries)
- Simplify "Performance" section (remove 2016 blog post links, keep essential info)
- Remove ReactJs page reference