### PR TITLE
Replace SQL batch section with BDR + #[Embed] recipe

### DIFF
--- a/manuals/1.0/en/async.md
+++ b/manuals/1.0/en/async.md
@@ -157,52 +157,79 @@ Each runtime requires the corresponding PHP extension.
 | ext-parallel | ZTS PHP + ext-parallel | add `bin/async.php` |
 | ext-swoole | ext-swoole | install `AsyncSwooleModule`, use `bin/swoole.php` |
 
-## SQL batch execution
+## SQL resources with BDR + `#[Embed]`
 
-Parallel SQL query execution using mysqli's native async support is also provided.
+To run multiple SQL queries for one page, split each query into its own `ResourceObject` and let `#[Embed]` parallelize them via AsyncLinker. The call site just composes resources — the runtime decides how to execute the embeds in parallel.
 
-```php
-use BEAR\Async\Module\MysqliEnvModule;
+Combined with Ray.MediaQuery's [BDR pattern](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md) (`#[DbQuery]` interface + factory + immutable domain object), SQL stays in `var/sql/*.sql`, the call site reads as plain objects, and the resource graph itself is what gets parallelized.
 
-$this->install(new MysqliEnvModule(
-    'MYSQLI_HOST',
-    'MYSQLI_USER',
-    'MYSQLI_PASSWORD',
-    'MYSQLI_DATABASE',
-));
+Recipe dependency (not bundled with BEAR.Async):
+
+```bash
+composer require ray/media-query
 ```
 
 ```php
-use BEAR\Async\SqlBatch;
-use BEAR\Async\SqlBatchExecutorInterface;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+use Ray\MediaQuery\Annotation\DbQuery;
 
-class MyService
+// Domain object — immutable snapshot
+final class UserAccount
 {
     public function __construct(
-        private SqlBatchExecutorInterface $executor,
-    ) {}
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+    }
+}
 
-    public function getData(int $userId): array
+// Repository — SQL lives in var/sql/user.sql.
+// UserFactory hydrates the row into UserAccount; see BDR_PATTERN.md for factory details.
+interface UserRepositoryInterface
+{
+    #[DbQuery('user', factory: UserFactory::class)]
+    public function getUser(int $id): UserAccount;
+}
+
+// Resource — one resource per SQL
+class User extends ResourceObject
+{
+    public function __construct(private UserRepositoryInterface $repo)
     {
-        $results = (new SqlBatch($this->executor, [
-            'user' => ['SELECT * FROM users WHERE id = :id', ['id' => $userId]],
-            'posts' => ['SELECT * FROM posts WHERE user_id = :user_id', ['user_id' => $userId]],
-            'comments' => ['SELECT * FROM comments WHERE user_id = :user_id', ['user_id' => $userId]],
-        ]))();
+    }
 
-        return [
-            'user' => $results['user'][0] ?? null,
-            'posts' => $results['posts'],
-            'comments' => $results['comments'],
-        ];
+    public function onGet(int $id): static
+    {
+        $this->body = ['user' => $this->repo->getUser($id)];
+
+        return $this;
+    }
+}
+
+// Aggregate — Embeds parallelize automatically under AsyncLinker
+class UserDashboard extends ResourceObject
+{
+    #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
+    #[Embed(rel: 'posts',    src: 'app://self/user/posts{?id}')]
+    #[Embed(rel: 'comments', src: 'app://self/user/comments{?id}')]
+    public function onGet(int $id): static
+    {
+        return $this;
     }
 }
 ```
+
+- SQL stays in `var/sql/*.sql` (Ray.MediaQuery convention)
+- Domain objects are immutable snapshots; no `$results['user'][0] ?? null` plumbing at the call site
+- AsyncLinker runs the three embeds in parallel via ext-parallel (PHP-FPM / Apache) or Swoole coroutines
+- Without ext-parallel and without Swoole the same code runs synchronously per request, which is fine for PHP-FPM (each request is its own process)
+- For Swoole, install `PdoPoolModule` so each coroutine borrows a pooled PDO connection
 
 ## References
 
 - [BEAR.Async](https://github.com/bearsunday/BEAR.Async)
 - [BEAR.Async Demo Guide](https://github.com/bearsunday/BEAR.Async/tree/1.x/demo)
 - [BEAR.Async Benchmark Results](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md)
-- [BEAR.Projection](https://github.com/bearsunday/BEAR.Projection)
+- [Ray.MediaQuery BDR Pattern](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md)
 - [Parallel Execution Architecture](https://bearsunday.github.io/BEAR.Async/parallel-execution-architecture.html)

--- a/manuals/1.0/en/async.md
+++ b/manuals/1.0/en/async.md
@@ -224,7 +224,7 @@ class UserDashboard extends ResourceObject
 - Domain objects are immutable snapshots; no `$results['user'][0] ?? null` plumbing at the call site
 - AsyncLinker runs the three embeds in parallel via ext-parallel (PHP-FPM / Apache) or Swoole coroutines
 - Without ext-parallel and without Swoole the same code runs synchronously per request, which is fine for PHP-FPM (each request is its own process)
-- For Swoole, install `PdoPoolModule` so each coroutine borrows a pooled PDO connection
+- For Swoole, install `PdoPoolEnvModule` so each coroutine borrows a pooled PDO connection
 
 ## References
 

--- a/manuals/1.0/ja/async.md
+++ b/manuals/1.0/ja/async.md
@@ -224,7 +224,7 @@ class UserDashboard extends ResourceObject
 - ドメインオブジェクトは不変スナップショット。呼び出し側で `$results['user'][0] ?? null` のような配列のお作法は不要
 - AsyncLinkerが3つのEmbedをext-parallel（PHP-FPM / Apache）またはSwooleコルーチンで並列実行
 - ext-parallel/Swooleなしでも、同じコードがリクエストごとに同期実行される（PHP-FPMはリクエスト＝プロセスなので機能としては問題なし）
-- Swooleで動かす場合は`PdoPoolModule`をインストールし、各コルーチンがプールからPDO接続を借りるようにする
+- Swooleで動かす場合は`PdoPoolEnvModule`をインストールし、各コルーチンがプールからPDO接続を借りるようにする
 
 ## 参考リンク
 

--- a/manuals/1.0/ja/async.md
+++ b/manuals/1.0/ja/async.md
@@ -157,52 +157,79 @@ BEAR.AsyncリポジトリにはSync・ext-parallel・Swooleの動作を比較で
 | ext-parallel | ZTS PHP + ext-parallel | `bin/async.php`を追加 |
 | ext-swoole | ext-swoole | `AsyncSwooleModule`をインストール、`bin/swoole.php`を使用 |
 
-## SQLバッチ実行
+## SQLリソースの並列化（BDR + `#[Embed]`）
 
-mysqliのネイティブ非同期サポートを使用した並列SQLクエリ実行も提供します。
+1ページで複数のSQLを発行したい場合、SQLごとにResourceObjectを分け、上位リソースから`#[Embed]`で束ねます。AsyncLinkerが`#[Embed]`をランタイムに応じて並列実行するので、利用側はリソースを組み合わせるだけで並列化されます。
 
-```php
-use BEAR\Async\Module\MysqliEnvModule;
+Ray.MediaQueryの[BDRパターン](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md)（`#[DbQuery]`インターフェース + ファクトリ + 不変ドメインオブジェクト）と組み合わせると、SQLは`var/sql/*.sql`にまとまり、リソース側はドメインオブジェクトを扱うだけになります。
 
-$this->install(new MysqliEnvModule(
-    'MYSQLI_HOST',
-    'MYSQLI_USER',
-    'MYSQLI_PASSWORD',
-    'MYSQLI_DATABASE',
-));
+レシピ依存（BEAR.Asyncには同梱されません）:
+
+```bash
+composer require ray/media-query
 ```
 
 ```php
-use BEAR\Async\SqlBatch;
-use BEAR\Async\SqlBatchExecutorInterface;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+use Ray\MediaQuery\Annotation\DbQuery;
 
-class MyService
+// ドメインオブジェクト — 不変スナップショット
+final class UserAccount
 {
     public function __construct(
-        private SqlBatchExecutorInterface $executor,
-    ) {}
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+    }
+}
 
-    public function getData(int $userId): array
+// リポジトリ — SQLは var/sql/user.sql に置く
+// UserFactoryで行をUserAccountにハイドレートする（ファクトリの詳細はBDR_PATTERN.md参照）
+interface UserRepositoryInterface
+{
+    #[DbQuery('user', factory: UserFactory::class)]
+    public function getUser(int $id): UserAccount;
+}
+
+// リソース — SQL 1つにつき1リソース
+class User extends ResourceObject
+{
+    public function __construct(private UserRepositoryInterface $repo)
     {
-        $results = (new SqlBatch($this->executor, [
-            'user' => ['SELECT * FROM users WHERE id = :id', ['id' => $userId]],
-            'posts' => ['SELECT * FROM posts WHERE user_id = :user_id', ['user_id' => $userId]],
-            'comments' => ['SELECT * FROM comments WHERE user_id = :user_id', ['user_id' => $userId]],
-        ]))();
+    }
 
-        return [
-            'user' => $results['user'][0] ?? null,
-            'posts' => $results['posts'],
-            'comments' => $results['comments'],
-        ];
+    public function onGet(int $id): static
+    {
+        $this->body = ['user' => $this->repo->getUser($id)];
+
+        return $this;
+    }
+}
+
+// 集約リソース — `#[Embed]` がAsyncLinkerで自動的に並列化される
+class UserDashboard extends ResourceObject
+{
+    #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
+    #[Embed(rel: 'posts',    src: 'app://self/user/posts{?id}')]
+    #[Embed(rel: 'comments', src: 'app://self/user/comments{?id}')]
+    public function onGet(int $id): static
+    {
+        return $this;
     }
 }
 ```
+
+- SQLは`var/sql/*.sql`に置く（Ray.MediaQueryの規約）
+- ドメインオブジェクトは不変スナップショット。呼び出し側で `$results['user'][0] ?? null` のような配列のお作法は不要
+- AsyncLinkerが3つのEmbedをext-parallel（PHP-FPM / Apache）またはSwooleコルーチンで並列実行
+- ext-parallel/Swooleなしでも、同じコードがリクエストごとに同期実行される（PHP-FPMはリクエスト＝プロセスなので機能としては問題なし）
+- Swooleで動かす場合は`PdoPoolModule`をインストールし、各コルーチンがプールからPDO接続を借りるようにする
 
 ## 参考リンク
 
 - [BEAR.Async](https://github.com/bearsunday/BEAR.Async)
 - [BEAR.Async デモガイド](https://github.com/bearsunday/BEAR.Async/tree/1.x/demo)
 - [BEAR.Async ベンチマーク結果](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md)
-- [BEAR.Projection](https://github.com/bearsunday/BEAR.Projection)
+- [Ray.MediaQuery BDRパターン](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md)
 - [並列実行アーキテクチャ](https://bearsunday.github.io/BEAR.Async/parallel-execution-architecture.html)


### PR DESCRIPTION
## Summary

- BEAR.Async 1.x removed `SqlBatch`, `Mysqli\*`, and the `BEAR\Projection\` namespace (see [BEAR.Async#24](https://github.com/bearsunday/BEAR.Async/pull/24)).
- The "SQL batch execution" example in `async.md` referenced those removed symbols, so it is replaced with the BDR + `#[Embed]` recipe: split each SQL into its own `ResourceObject` and let `AsyncLinker` parallelize the embeds.
- Combined with Ray.MediaQuery's [BDR pattern](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md), SQL stays in `var/sql/*.sql` and the call site reads as plain objects — no `$results['user'][0] ?? null` plumbing.

The independent `bearsunday/BEAR.Projection` repository is unaffected, so the `BEAR.Projection` reference in `database.md` is intentionally left as-is.

## Test plan

- [ ] Render `manuals/1.0/ja/async.md` and `manuals/1.0/en/async.md` locally to confirm formatting
- [ ] Verify no remaining references to `SqlBatch` / `MysqliEnvModule` / `BEAR\Async\Module\Mysqli*` under `manuals/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 非同期SQL実行のベストプラクティスをBDRパターンと#[Embed]アノテーションを活用した新しい手法に更新しました。
  * SQLリソースの並列化方法、実装例、および設定要件に関する詳細情報を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bearsunday/bearsunday.github.io/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->