### PR TITLE
docs(form): correct CSRF protection wording for SetAntiCsrfTrait

### DIFF
--- a/manuals/1.0/en/form.md
+++ b/manuals/1.0/en/form.md
@@ -133,7 +133,12 @@ echo $form;  // render the entire form HTML
 
 ## CSRF Protections
 
-CSRF protection is **opt-in**. A form that uses `SetAntiCsrfTrait` is wired with an `AntiCsrfInterface`, but the token is only verified on methods annotated with `#[CsrfProtection]`. Methods without `#[CsrfProtection]` perform no CSRF check even if the form has an `AntiCsrf` object set.
+CSRF protection is **opt-in** and can be enabled through either of two independent paths:
+
+- **Per-form**: add `use SetAntiCsrfTrait;` to the form. `AntiCsrfInterface` is injected at construction time, the token field is added in `postConstruct()`, and every `apply()` call verifies the token.
+- **Per-action**: annotate the validated method with `#[CsrfProtection]`. `AuraInputInterceptor` then injects `AntiCsrfInterface` into the form before `apply()` runs.
+
+Either path causes `AbstractForm::apply()` to throw `CsrfViolationException` on token mismatch. Without either path, no CSRF check is performed.
 
 ```php
 use BEAR\Resource\ResourceObject;

--- a/manuals/1.0/ja/form.md
+++ b/manuals/1.0/ja/form.md
@@ -133,7 +133,12 @@ echo $form;  // フォーム全体のHTMLを描画
 
 ## CSRF
 
-CSRF(クロスサイトリクエストフォージェリ)保護はopt-inです。フォームに`SetAntiCsrfTrait`を使うと`AntiCsrfInterface`が組み込まれますが、トークンの検証は`#[CsrfProtection]`アトリビュートを付けたメソッドでのみ実行されます。アトリビュートが無いメソッドでは、フォームが`AntiCsrf`オブジェクトを持っていてもCSRF検証は行われません。
+CSRF(クロスサイトリクエストフォージェリ)保護は**opt-in**で、独立した2つの経路のいずれかで有効化できます。
+
+- **フォーム単位**: フォームに`use SetAntiCsrfTrait;`を追加します。DIで`AntiCsrfInterface`が注入され、`postConstruct()`でトークンフィールドが追加され、`apply()`の呼び出しごとにトークンが検証されます。
+- **アクション単位**: バリデーション対象のメソッドに`#[CsrfProtection]`を付与します。`AuraInputInterceptor`が`apply()`実行前に`AntiCsrfInterface`をフォームへ注入します。
+
+どちらの経路でも、トークン不一致時には`AbstractForm::apply()`が`CsrfViolationException`をthrowします。どちらも使わない場合はCSRF検証は行われません。
 
 ```php
 use BEAR\Resource\ResourceObject;


### PR DESCRIPTION
## Summary

Fixes #360.

The "CSRF Protections" / "CSRF" sections in `manuals/1.0/en/form.md` and `manuals/1.0/ja/form.md` incorrectly stated that `#[CsrfProtection]` was required for token verification when using `SetAntiCsrfTrait`. In reality, `SetAntiCsrfTrait` alone enforces verification via DI + `postConstruct()` on every `apply()` call.

This PR applies the patch proposed in the issue, documenting the two independent opt-in paths:

- **Per-form**: `use SetAntiCsrfTrait;` — always-on for that form.
- **Per-action**: `#[CsrfProtection]` on the controller method — interceptor injects antiCsrf before `apply()`.

Either path causes `AbstractForm::apply()` to throw `CsrfViolationException` on token mismatch.

## Test plan

- [x] EN docs updated (`manuals/1.0/en/form.md`)
- [x] JA docs updated (`manuals/1.0/ja/form.md`)
- [ ] Preview renders correctly on the docs site after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rh6X97jnhDP7BzSqUkaf2j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * CSRF保護機能に関するドキュメントを更新。opt-in有効化の2つの方法（フォーム側での `SetAntiCsrfTrait` 使用とアクション側での `#[CsrfProtection]` 属性付与）と動作について明確化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bearsunday/bearsunday.github.io/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->