### PR TITLE
Document Input DTO responsibilities in resource parameters manual

### DIFF
--- a/manuals/1.0/en/resource_param.md
+++ b/manuals/1.0/en/resource_param.md
@@ -89,6 +89,45 @@ Namespaces are arbitrary. Input classes can implement methods to aggregate or va
 
 Use the `#[Input]` attribute to leverage type-safe input object generation from the `Ray.InputQuery` library.
 
+By grouping BEAR.Resource request parameters into an Input DTO, the Resource method can stay focused on receiving HTTP input and building the response. Types, default values, normalization such as `trim()`, and validation such as format checks can be centralized in the input object. The same DTO is also easy to pass on to Query or MediaQuery.
+
+```php
+use InvalidArgumentException;
+use Ray\InputQuery\Attribute\Input;
+
+final class SearchInput
+{
+    public readonly string $keyword;
+
+    public function __construct(
+        #[Input] string $keyword,
+        #[Input] public readonly int $page = 1
+    ) {
+        $this->keyword = trim($keyword);
+
+        if ($this->keyword === '') {
+            throw new InvalidArgumentException('keyword is required');
+        }
+
+        if ($this->page < 1) {
+            throw new InvalidArgumentException('page must be greater than 0');
+        }
+    }
+}
+
+class Search extends ResourceObject
+{
+    public function onGet(#[Input] SearchInput $input): static
+    {
+        // The same Input DTO can be passed to Query / MediaQuery
+        $this->body = $this->searchQuery->get($input);
+        return $this;
+    }
+}
+```
+
+> Note: Even for a single input value, a DTO such as `NameInput` can keep `trim()` and format checks inside the constructor. DTOs are not only for grouping multiple parameters.
+
 ```php
 use Ray\InputQuery\Attribute\Input;
 

--- a/manuals/1.0/ja/resource_param.md
+++ b/manuals/1.0/ja/resource_param.md
@@ -90,6 +90,45 @@ final class User
 
 `#[Input]`属性を使って、`Ray.InputQuery`ライブラリによる型安全な入力オブジェクトの生成を利用できます。
 
+BEAR.ResourceのリクエストパラメーターをInput DTOにまとめると、ResourceメソッドはHTTP入力を受け取りレスポンスを組み立てる責務に集中できます。入力の型、デフォルト値、`trim()`などの正規化、形式チェックなどの検証は入力オブジェクト側に集約でき、同じDTOをQueryやMediaQueryなどへ渡しやすくなります。
+
+```php
+use InvalidArgumentException;
+use Ray\InputQuery\Attribute\Input;
+
+final class SearchInput
+{
+    public readonly string $keyword;
+
+    public function __construct(
+        #[Input] string $keyword,
+        #[Input] public readonly int $page = 1
+    ) {
+        $this->keyword = trim($keyword);
+
+        if ($this->keyword === '') {
+            throw new InvalidArgumentException('keyword is required');
+        }
+
+        if ($this->page < 1) {
+            throw new InvalidArgumentException('page must be greater than 0');
+        }
+    }
+}
+
+class Search extends ResourceObject
+{
+    public function onGet(#[Input] SearchInput $input): static
+    {
+        // Query / MediaQueryへ同じInput DTOを渡せます
+        $this->body = $this->searchQuery->get($input);
+        return $this;
+    }
+}
+```
+
+> Note: 入力値が1つだけの場合でも、`NameInput`のようなDTOにすることで、`trim()`や形式チェックをコンストラクタに閉じ込められます。DTO化は複数パラメーターをまとめるためだけのものではありません。
+
 ```php
 use Ray\InputQuery\Attribute\Input;
 


### PR DESCRIPTION
## Summary
- Add guidance that Input DTOs centralize request parameter types, defaults, normalization, and validation for BEAR.Resource methods.
- Clarify that `#[Input]` lets Ray.InputQuery generate and inject typed DTOs.
- Mention passing the same Input DTO to Query / MediaQuery, with a short note that DTOs can still be useful for single input values.
- Add the corresponding English manual update.

## Validation
- `git diff --check`
- Python check that fenced code blocks are balanced in the changed Markdown files
- `bundle exec jekyll build --trace` (failed: required gems such as jekyll/minima are not installed locally; no dependency install was attempted)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Ray.InputQuery統合に関するセクションを拡充し、リクエストパラメータをInput DTOで管理する方法を詳述
  * SearchInputDTOのサンプルコードを追加し、trim()やバリデーション処理を実装例で紹介
  * 単一値の入力でもDTO化が可能であることを説明

<!-- end of auto-generated comment: release notes by coderabbit.ai -->