### PR TITLE
Fix Learn site snapshot checks for /ja/ /en/ URL structure

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -110,9 +110,12 @@ jobs:
           # /bear-logo.png and /favicon.svg rules below relativize.
           find snapshot -name '*.html' -print0 | xargs -0 sed -i "s#url(http://localhost:4399/[^)]*)#url('bear-logo.png')#g;s#/bear-logo.png#bear-logo.png#g;s#/favicon.svg#favicon.svg#g"
           test -f snapshot/index.html
-          test -f snapshot/rest.html
-          test -f snapshot/tech.html
-          test -f snapshot/alps.html
+          test -f snapshot/ja/rest.html
+          test -f snapshot/ja/tech.html
+          test -f snapshot/ja/alps.html
+          test -f snapshot/en/rest.html
+          test -f snapshot/en/tech.html
+          test -f snapshot/en/alps.html
           test -f snapshot/bear-logo.png
 
       - name: Place Learn under /learn/


### PR DESCRIPTION
## Summary

The Learn site (bearsunday/site-bear-sunday) is moving from flat URLs (`/rest`, `/tech`, `/alps`) to language-prefixed URLs (`/ja/rest`, `/en/rest`, etc.).

This updates the snapshot existence checks in the deploy workflow to match the new URL structure, verifying representative pages exist for both Japanese and English.

## Changes
- `snapshot/rest.html` → `snapshot/ja/rest.html` + `snapshot/en/rest.html`
- `snapshot/tech.html` → `snapshot/ja/tech.html` + `snapshot/en/tech.html`
- `snapshot/alps.html` → `snapshot/ja/alps.html` + `snapshot/en/alps.html`

`snapshot/index.html` and `snapshot/bear-logo.png` remain unchanged.