### PR TITLE
Restructure Learn site snapshot: .html into directory index.html

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -109,13 +109,21 @@ jobs:
           # filename only survives untouched inside the (JSON) RSC payload, which the two
           # /bear-logo.png and /favicon.svg rules below relativize.
           find snapshot -name '*.html' -print0 | xargs -0 sed -i "s#url(http://localhost:4399/[^)]*)#url('bear-logo.png')#g;s#/bear-logo.png#bear-logo.png#g;s#/favicon.svg#favicon.svg#g"
+          # Restructure .html files into directory index.html so /ja/ works naturally
+          for f in snapshot/ja snapshot/en snapshot/ja/*.html snapshot/en/*.html; do
+            if [ -f "$f" ]; then
+              dir="${f%.html}"
+              mkdir -p "$dir"
+              mv "$f" "$dir/index.html"
+            fi
+          done
           test -f snapshot/index.html
-          test -f snapshot/ja/rest.html
-          test -f snapshot/ja/tech.html
-          test -f snapshot/ja/alps.html
-          test -f snapshot/en/rest.html
-          test -f snapshot/en/tech.html
-          test -f snapshot/en/alps.html
+          test -f snapshot/ja/rest/index.html
+          test -f snapshot/ja/tech/index.html
+          test -f snapshot/ja/alps/index.html
+          test -f snapshot/en/rest/index.html
+          test -f snapshot/en/tech/index.html
+          test -f snapshot/en/alps/index.html
           test -f snapshot/bear-logo.png
 
       - name: Place Learn under /learn/


### PR DESCRIPTION
## Problem
wget -E creates flat .html files (ja.html, ja/business.html). GitHub Pages serves these at /ja, /ja/business without trailing slash. But /ja/ (with trailing slash) 404s.

## Fix
After wget crawl, restructure .html files into directory index.html:
- ja.html → ja/index.html
- en.html → en/index.html  
- ja/business.html → ja/business/index.html
- etc.

Now /ja/ and /ja/business/ both work naturally.