### PR TITLE
Expand the Ray.WebQuery note in the MediaQuery manual

### DIFF
--- a/manuals/1.0/en/database.media.md
+++ b/manuals/1.0/en/database.media.md
@@ -19,7 +19,7 @@ permalink: /manuals/1.0/en/database_media.html
 composer require ray/media-query
 ```
 
-> **Note**: For the same interface-driven approach over Web APIs, see [ray/web-query](https://github.com/ray-di/Ray.WebQuery).
+> **Note**: Web APIs can be handled the same way from an interface. Use [ray/web-query](https://github.com/ray-di/Ray.WebQuery) (`composer require ray/web-query`), which maps HTTP requests to interface methods with `#[WebQuery]`.
 
 ## Usage
 

--- a/manuals/1.0/ja/database.media.md
+++ b/manuals/1.0/ja/database.media.md
@@ -19,7 +19,7 @@ permalink: /manuals/1.0/ja/database_media.html
 composer require ray/media-query
 ```
 
-> **Note**: Web APIを同様にインターフェイスから扱うには [ray/web-query](https://github.com/ray-di/Ray.WebQuery) を参照してください。
+> **Note**: Web API も同様にインターフェイスから扱えます。HTTP リクエストを `#[WebQuery]` でインターフェイスのメソッドにマッピングする [ray/web-query](https://github.com/ray-di/Ray.WebQuery)（`composer require ray/web-query`）を利用してください。
 
 ## 利用方法
 


### PR DESCRIPTION
The MediaQuery manual only pointed to [ray/web-query](https://github.com/ray-di/Ray.WebQuery) with a bare one-line link. This expands the note so readers can tell at a glance whether the package fits their use case:

- mention the install command (`composer require ray/web-query`)
- state that `#[WebQuery]` maps HTTP requests to interface methods

Applied to both ja and en `database.media.md`. Detailed usage stays in the ray/web-query README (now corrected; package just reached 1.0.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `Ray.MediaQuery` の案内を更新し、Web API でも同じようにインターフェースベースで扱えることを明記しました。
  * 関連する参照先とインストール手順を追記し、利用開始までの案内をわかりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->