### PR TITLE
Fix lazy request syntax in ja/resource.md

### DIFF
--- a/manuals/1.0/en/resource.md
+++ b/manuals/1.0/en/resource.md
@@ -174,7 +174,7 @@ $posts = $this->resource->get('app://self/posts', ['id' => 1]);
 The above is an `eager` request that makes the request immediately, but it is also possible to generate a request and delay execution instead of the request result.
 
 ```php
-$request = $this->resource->get('app://self/posts'); // callable
+$request = $this->resource->get->uri('app://self/posts'); // callable
 $posts = $request(['id' => 1]);
 ```
 
@@ -182,7 +182,7 @@ When this request is embedded in a template or resource, it is evaluated lazily.
 
 ```php
 $this->body = [
-    'lazy' => $this->resource->get('app://self/posts')->withQuery(['id' => 3])->request();
+    'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])
 ];
 ```
 

--- a/manuals/1.0/en/resource.md
+++ b/manuals/1.0/en/resource.md
@@ -174,8 +174,8 @@ $posts = $this->resource->get('app://self/posts', ['id' => 1]);
 The above is an `eager` request that makes the request immediately, but it is also possible to generate a request and delay execution instead of the request result.
 
 ```php
-$request = $this->resource->get->uri('app://self/posts'); // callable
-$posts = $request(['id' => 1]);
+$request = $this->resource->get->uri('app://self/posts')->withQuery(['id' => 1]); // callable
+$posts = $request();
 ```
 
 When this request is embedded in a template or resource, it is evaluated lazily. That is, when it is not evaluated, the request is not made and has no execution cost.
@@ -185,6 +185,8 @@ $this->body = [
     'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])
 ];
 ```
+
+The `#[Embed]` attribute provides a declarative way to achieve the same lazy embedding. See [Resource Link](resource_link.html) for details.
 
 ## Cache
 

--- a/manuals/1.0/ja/resource.md
+++ b/manuals/1.0/ja/resource.md
@@ -175,8 +175,8 @@ $posts = $this->resource->uri('app://self/posts')(['id' => 1]);
 これまでの例はリクエストをすぐに行う`eager`リクエストですが、リクエスト結果ではなくリクエストを生成し、実行を遅延することもできます。
 
 ```php
-$request = $this->resource->get->uri('app://self/posts'); // callable
-$posts = $request(['id' => 1]);
+$request = $this->resource->get->uri('app://self/posts')->withQuery(['id' => 1]); // callable
+$posts = $request();
 ```
 
 このリクエストをテンプレートやリソースに埋め込むと、遅延評価されます。つまり評価されない時はリクエストは行われず、実行コストがかかりません。
@@ -186,6 +186,8 @@ $this->body = [
     'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])
 ];
 ```
+
+`#[Embed]`アトリビュートを使うと、同じ遅延埋め込みを宣言的に記述できます。詳しくは[リソースリンク](resource_link.html)をご覧ください。
 
 ## キャッシュ
 

--- a/manuals/1.0/ja/resource.md
+++ b/manuals/1.0/ja/resource.md
@@ -175,7 +175,7 @@ $posts = $this->resource->uri('app://self/posts')(['id' => 1]);
 これまでの例はリクエストをすぐに行う`eager`リクエストですが、リクエスト結果ではなくリクエストを生成し、実行を遅延することもできます。
 
 ```php
-$request = $this->resource->get('app://self/posts'); // callable
+$request = $this->resource->get->uri('app://self/posts'); // callable
 $posts = $request(['id' => 1]);
 ```
 
@@ -183,7 +183,7 @@ $posts = $request(['id' => 1]);
 
 ```php
 $this->body = [
-    'lazy' => $this->resource->get('app://self/posts')->withQuery(['id' => 3])->request()
+    'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])->request()
 ];
 ```
 

--- a/manuals/1.0/ja/resource.md
+++ b/manuals/1.0/ja/resource.md
@@ -183,7 +183,7 @@ $posts = $request(['id' => 1]);
 
 ```php
 $this->body = [
-    'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])->request()
+    'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])
 ];
 ```
 


### PR DESCRIPTION
## Summary

- `get('uri')` is immediate execution (eager); `get->uri('uri')` creates a callable lazy request
- Fix both code examples in the 遅延評価 section of `manuals/1.0/ja/resource.md`

```diff
-$request = $this->resource->get('app://self/posts'); // callable
+$request = $this->resource->get->uri('app://self/posts'); // callable

-    'lazy' => $this->resource->get('app://self/posts')->withQuery(['id' => 3])->request()
+    'lazy' => $this->resource->get->uri('app://self/posts')->withQuery(['id' => 3])->request()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 「遅延評価」セクションのコード例を更新し、リクエスト生成の記述を新しい形式に統一しました。
  * テンプレートやリソース埋め込み向けの `lazy` 例もあわせて見直し、より一貫したサンプルになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->