### PR TITLE
Document PagesInterface::getNbPages() and Page::$nbPages

### DIFF
--- a/manuals/1.0/en/database.aura.md
+++ b/manuals/1.0/en/database.aura.md
@@ -505,6 +505,7 @@ $page = $pager[2]; // page 2
 // $page->data // sliced data (array|\Traversable)
 // $page->current; (int)
 // $page->total (int)
+// $page->nbPages (int)
 // $page->hasNext (bool)
 // $page->hasPrevious (bool)
 // $page->maxPerPage; (int)

--- a/manuals/1.0/en/database.media.md
+++ b/manuals/1.0/en/database.media.md
@@ -355,16 +355,18 @@ interface TodoList
 }
 ```
 
-You can get the count with `count()`, and get page objects with array access by page number. `PagesInterface` is a SQL lazy execution object.
+You can get the count with `count()`, the number of pages with `getNbPages()`, and get page objects with array access by page number. `PagesInterface` is a SQL lazy execution object.
 
 ```php
 $pages = ($todoList)();
-$cnt = count($pages);    // Count SQL is generated and queried when count() is called
-$page = $pages[2];       // DB query for that page is executed when array access is made
+$cnt = count($pages);           // Count SQL is generated and queried when count() is called
+$nbPages = $pages->getNbPages(); // total number of pages (no need to compute ceil(count / perPage))
+$page = $pages[2];              // DB query for that page is executed when array access is made
 
 // $page->data           // sliced data
 // $page->current;       // current page number
 // $page->total          // total count
+// $page->nbPages        // total number of pages
 // $page->hasNext        // whether next page exists
 // $page->hasPrevious    // whether previous page exists
 // $page->maxPerPage;    // maximum items per page

--- a/manuals/1.0/ja/database.aura.md
+++ b/manuals/1.0/ja/database.aura.md
@@ -641,6 +641,7 @@ $page = $pager[2];                          // page 2
 // $page->data             // sliced data (array|\Traversable)
 // $page->current;         // (int)
 // $page->total           // (int)
+// $page->nbPages         // (int)
 // $page->hasNext         // (bool)
 // $page->hasPrevious     // (bool)
 // $page->maxPerPage;     // (int)

--- a/manuals/1.0/ja/database.media.md
+++ b/manuals/1.0/ja/database.media.md
@@ -355,16 +355,18 @@ interface TodoList
 }
 ```
 
-`count()`で件数が取得でき、ページ番号で配列アクセスをするとページオブジェクトが取得できます。`PagesInterface`はSQL遅延実行オブジェクトです。
+`count()`で件数、`getNbPages()`で総ページ数が取得でき、ページ番号で配列アクセスをするとページオブジェクトが取得できます。`PagesInterface`はSQL遅延実行オブジェクトです。
 
 ```php
 $pages = ($todoList)();
-$cnt = count($pages);    // count()をした時にカウントSQLが生成されクエリーが行われます。
-$page = $pages[2];       // 配列アクセスをした時にそのページのDBクエリーが行われます。
+$cnt = count($pages);           // count()をした時にカウントSQLが生成されクエリーが行われます。
+$nbPages = $pages->getNbPages(); // 総ページ数（ceil(count / perPage)の計算が不要です）
+$page = $pages[2];              // 配列アクセスをした時にそのページのDBクエリーが行われます。
 
 // $page->data           // sliced data
 // $page->current;       // 現在のページ番号
 // $page->total          // 総件数
+// $page->nbPages        // 総ページ数
 // $page->hasNext        // 次ページの有無
 // $page->hasPrevious    // 前ページの有無
 // $page->maxPerPage;    // 1ページあたりの最大件数


### PR DESCRIPTION
## Summary

The pagination example in `database.media.md` (JA and EN) showed only `count()` and the `Page` properties (`total`/`current`/`hasNext`/`hasPrevious`/`maxPerPage`). This adds the new page-count API to the example so readers can obtain the total number of pages without recomputing `ceil(count / perPage)` by hand.

## Changes

- `manuals/1.0/ja/database.media.md`
- `manuals/1.0/en/database.media.md`

Both files:
- Mention `getNbPages()` in the lead paragraph.
- Add `$pages->getNbPages()` to the code example.
- Add `$page->nbPages` to the `Page` property list.

## Depends on

This documents APIs that are not yet released. Merge **after** the following library PRs land and are released:

- ray-di/Ray.AuraSqlModule#92 — adds `Page::$nbPages`
- ray-di/Ray.MediaQuery#108 — adds `PagesInterface::getNbPages()`

If either library PR changes its API during review, this manual PR should be updated to match before merging.

Draft until the library PRs are merged and released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * ページネーションの説明を更新し、`getNbPages()` による総ページ数の取得方法を明確にしました。
  * 件数取得・ページ取得の遅延実行に加え、総ページ数の参照方法と関連プロパティの例を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->