### PR TITLE
docs: recommend Compiler::fromInjector for compile

### DIFF
--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -163,37 +163,49 @@ Refer to the [existing implementation ProdLogger](https://github.com/bearsunday/
 
 ### Compilation Recommended
 
-When setting up, you can **warm up** the project using the `vendor/bin/bear.compile` script.
-The compile script creates all static cache files such as dynamically created files for DI/AOP and annotations in advance, and outputs an optimized autoload.php file and preload.php.
+When setting up, you can **warm up** the project: create static cache files for DI/AOP and annotations in advance, and write optimized `autoload.php` and `preload.php`.
+
+The recommended entry is `Compiler::fromInjector()` with the same application `Injector` used at runtime (BEAR.Package 1.21+; skeleton ships `bin/compile.php`).
+
+```php
+// bin/compile.php
+use BEAR\Package\Compiler;
+use MyVendor\MyProject\Injector;
+
+$context = $argv[1] ?? 'prod-app';
+
+exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+```
+
+```json
+"scripts": {
+    "compile": "php bin/compile.php prod-app"
+}
+```
 
 * If you compile, the possibility of DI errors at runtime is extremely low because injection is performed in all classes.
 * The contents included in `.env` are incorporated into the PHP file, so `.env` can be deleted after compilation.
 
-When compiling multiple contexts (ex. api-app, html-app) in one application, such as when performing content negotiation, it is necessary to evacuate the files.
+When compiling multiple contexts (e.g. api-app and html-app for content negotiation), call `bin/compile.php` per context and evacuate shared root artifacts such as `autoload.php` when needed.
 
+```bash
+php bin/compile.php prod-hal-api-app
+mv autoload.php api.autoload.php
+php bin/compile.php prod-html-app
 ```
-mv autoload.php api.autoload.php  
-```
-
-Edit `composer.json` to change the content of `composer compile`.
 
 DI scripts are written under `{tmpDir}/di` (default `tmpDir` is `var/tmp/{context}`). The defaults are fine for most deployments.
+
+`vendor/bin/bear.compile` is deprecated. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
 
 #### Changing writable paths {: #writable-paths }
 
 Optional. Use only when temporary files or logs should live outside the project tree—for example a read-only app root (some serverless or container layouts), or when build-time and runtime writable paths differ. Ordinary VPS or shared hosting does not need this.
 
-Pass resolved paths to the `Meta` constructor (interpreting environment variables is an application concern):
+Pass resolved paths to the `Meta` constructor (interpreting environment variables is an application concern). With `Compiler::fromInjector()`, compile uses the same Meta.
 
 ```php
 new Meta($name, $context, $appDir, '/var/tmp/my-app', '/var/log/my-app');
-```
-
-To compile against the same paths, use `Compiler::fromInjector()` with the application `Injector` (`bear.compile` remains available as before):
-
-```php
-// example bin/compile.php
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
 ```
 
 ### autoload.php

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -186,11 +186,12 @@ exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
 * If you compile, the possibility of DI errors at runtime is extremely low because injection is performed in all classes.
 * The contents included in `.env` are incorporated into the PHP file, so `.env` can be deleted after compilation.
 
-When compiling multiple contexts (e.g. api-app and html-app for content negotiation), call `bin/compile.php` per context and evacuate shared root artifacts such as `autoload.php` when needed.
+When compiling multiple contexts (e.g. api-app and html-app for content negotiation), call `bin/compile.php` per context and evacuate project-root `autoload.php` / `preload.php` so a later compile does not overwrite them.
 
 ```bash
 php bin/compile.php prod-hal-api-app
 mv autoload.php api.autoload.php
+mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -179,11 +179,12 @@ exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
 ```
 
 * コンパイルをすれば全てのクラスでインジェクションを行うのでランタイムでDIのエラーが出る可能性が極めて低くなります。
-* `.env`に含まれた内容はPHPファイルに取り込まれるのでコンパイル後に`.env`を消去可能です。コンテントネゴシエーションを行う場合など（例：api-app, html-app）1つのアプリケーションで複数コンテキストのコンパイルを行うときには、コンテキストごとに `bin/compile.php` を呼び、必要なら `autoload.php` などの退避が必要です。
+* `.env`に含まれた内容はPHPファイルに取り込まれるのでコンパイル後に`.env`を消去可能です。コンテントネゴシエーションを行う場合など（例：api-app, html-app）1つのアプリケーションで複数コンテキストのコンパイルを行うときには、コンテキストごとに `bin/compile.php` を呼び、プロジェクト直下に出る `autoload.php` / `preload.php` を退避します（後続コンパイルで上書きされないようにします）。
 
 ```bash
 php bin/compile.php prod-hal-api-app
 mv autoload.php api.autoload.php
+mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -158,34 +158,47 @@ final class MyProdLoggerModule extends AbstractModule
 
 ### コンパイル
 
-推奨セットアップを行う際に`vendor/bin/bear.compile`スクリプトを使ってプロジェクトを**ウォームアップ**することができます。コンパイルスクリプトはDI/AOP用の動的に作成されるファイルやアノテーションなどの静的なキャッシュファイルを全て事前に作成し、最適化されたautoload.phpファイルとpreload.phpを出力します。
+セットアップ時にプロジェクトを**ウォームアップ**できます。DI/AOP 用の動的ファイルやアノテーションなどの静的キャッシュを事前に作成し、最適化された `autoload.php` と `preload.php` を出力します。
 
-* コンパイルをすれば全てのクラスでインジェクションを行うのでランタイムでDIのエラーが出る可能性が極めて低くなります。
-* `.env`には含まれた内容はPHPファイルに取り込まれるのでコンパイル後に`.env`を消去可能です。コンテントネゴシエーションを行う場合など（例：api-app, html-app）1つのアプリケーションで複数コンテキストのコンパイルを行うときにはファイルの退避が必要です。
+推奨は、ランタイムと同じアプリ `Injector` を使う `Compiler::fromInjector()` です（BEAR.Package 1.21+。スケルトンは `bin/compile.php`）。
 
-```bash
-mv autoload.php api.autoload.php
+```php
+// bin/compile.php
+use BEAR\Package\Compiler;
+use MyVendor\MyProject\Injector;
+
+$context = $argv[1] ?? 'prod-app';
+
+exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
 ```
 
-`composer.json`を編集して`composer compile`の内容を変更します。
+```json
+"scripts": {
+    "compile": "php bin/compile.php prod-app"
+}
+```
+
+* コンパイルをすれば全てのクラスでインジェクションを行うのでランタイムでDIのエラーが出る可能性が極めて低くなります。
+* `.env`に含まれた内容はPHPファイルに取り込まれるのでコンパイル後に`.env`を消去可能です。コンテントネゴシエーションを行う場合など（例：api-app, html-app）1つのアプリケーションで複数コンテキストのコンパイルを行うときには、コンテキストごとに `bin/compile.php` を呼び、必要なら `autoload.php` などの退避が必要です。
+
+```bash
+php bin/compile.php prod-hal-api-app
+mv autoload.php api.autoload.php
+php bin/compile.php prod-html-app
+```
 
 DI スクリプトの出力先は `{tmpDir}/di` です（既定の `tmpDir` は `var/tmp/{context}`）。ほとんどのデプロイではこの既定のままで問題ありません。
+
+`vendor/bin/bear.compile` は非推奨です。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
 
 #### 書き込み先を変える場合 {: #writable-paths }
 
 プロジェクトツリー外に一時ファイルやログを置きたいときだけ使います（任意）。例としては、アプリ本体が読み取り専用のホスト（一部の serverless / コンテナ構成）や、ビルド時と実行時で書き込みパスが分かれる場合です。通常の VPS や共有ホストでは不要です。
 
-`Meta` のコンストラクタに解決済みのパスを渡せます（環境変数の解釈はアプリ側の都合です）。
+`Meta` のコンストラクタに解決済みのパスを渡せます（環境変数の解釈はアプリ側の都合です）。`Compiler::fromInjector()` ならコンパイルも同じ Meta を使います。
 
 ```php
 new Meta($name, $context, $appDir, '/var/tmp/my-app', '/var/log/my-app');
-```
-
-コンパイルも同じパスにしたい場合は、アプリの `Injector` が組み立てた Meta をそのまま使う `Compiler::fromInjector()` があります（`bear.compile` は従来どおり使えます）。
-
-```php
-// bin/compile.php の例
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
 ```
 
 ### autoload.php


### PR DESCRIPTION
## Summary

- Production manual (ja/en): recommend app `bin/compile.php` + `Compiler::fromInjector()` as the compile entry
- Demote `vendor/bin/bear.compile` to deprecated with link to https://github.com/bearsunday/BEAR.Package/issues/482
- Multi-context example uses multiple `bin/compile.php` calls

## Related

- bearsunday/BEAR.Package#482
- bearsunday/BEAR.Package#481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 本番環境向けのコンパイル手順を、より現行の推奨方法に更新しました。
  * 複数の実行コンテキストをコンパイルする際の手順を追記しました。
  * 旧来のコンパイル方法が非推奨であることと、移行先の案内を追加しました。
  * 書き込み可能なパスの変更方法や、環境変数・依存性注入に関する注意事項を整理しました。
  * 英語版・日本語版の説明内容を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->