### PR TITLE
production: the $writeDir model, and a build entry that does not boot

### DIFF
--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -195,19 +195,58 @@ mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 
-DI scripts are written under `{tmpDir}/di` (default `tmpDir` is `var/tmp/{context}`). The defaults are fine for most deployments.
+DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build output: the deployment artifact carries them and runtime only reads them.
 
 `vendor/bin/bear.compile` is deprecated. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
 
-#### Changing writable paths {: #writable-paths }
+#### Read-only deployments (serverless, immutable containers) {: #writable-paths }
 
-Optional. Use only when temporary files or logs should live outside the project tree—for example a read-only app root (some serverless or container layouts), or when build-time and runtime writable paths differ. Ordinary VPS or shared hosting does not need this.
+Optional. Use it when the application tree is read-only at runtime and one directory is the only writable location: serverless platforms such as Vercel or AWS Lambda, or a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`. Ordinary VPS and shared hosting do not need it.
 
-Pass resolved paths to the `Meta` constructor (interpreting environment variables is an application concern). With `Compiler::fromInjector()`, compile uses the same Meta.
+Hand that directory to the boot, and to the build. It has to be an absolute path, and the two sides have to agree: the paths are compiled into the DI scripts. Both are enforced - a relative path throws `InvalidWriteDirException`, and a compile whose write directory differs from its injector's throws `WriteDirMismatchException`.
 
-```php
-new Meta($name, $context, $appDir, '/var/tmp/my-app', '/var/log/my-app');
+```diff
+ // public/index.php
+-exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER));
++exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
+
+ // bin/compile.php               php bin/compile.php prod-app /tmp
+-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
++$writeDir = $argv[2] ?? null;
++
++exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());
+
+ // src/Bootstrap.php
+-    public function __invoke(string $context, array $globals, array $server): int
++    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
+     {
+-        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
++        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
+
+ // src/Injector.php
+-    public static function getInstance(string $context): InjectorInterface
++    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
+     {
+-        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
++        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
+     }
 ```
+
+Development entry points pass nothing and keep the default paths. Reading environment variables is the entry point's business, not the framework's.
+
+With `/tmp` as the write directory:
+
+```text
+{appDir}/var/tmp/{context}/di                   compiled DI scripts, in the artifact
+/tmp/MyVendor/MyProject/{context}/tmp           query repository cache, serialized injector
+/tmp/MyVendor/MyProject/{context}/log
+```
+
+The application and the context are in the path because a deploy knows neither, and local cache keys are resource URIs: two applications or two contexts in one directory would answer with each other's entries. Compiled scripts stay under `appDir` - a new instance starts with an empty `/tmp`, so following the write directory would compile again on every cold start (0.38s against 0.018s on a five-resource application).
+
+Boot with a different write directory than the build used and the boot recompiles instead of using the old paths: loudly if the artifact is read-only, with a `Compiled DI scripts on demand` notice otherwise.
+
+Requires BEAR.Package 1.22+. Background: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491).
 
 ### autoload.php
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -165,17 +165,19 @@ Refer to the [existing implementation ProdLogger](https://github.com/bearsunday/
 
 When setting up, you can **warm up** the project: create static cache files for DI/AOP and annotations in advance, and write optimized `autoload.php` and `preload.php`.
 
-The recommended entry is `Compiler::fromInjector()` with the same application `Injector` used at runtime (BEAR.Package 1.21+; skeleton ships `bin/compile.php`).
+A build script names the application; it does not boot it (BEAR.Package 1.22+; the skeleton ships `bin/compile.php`).
 
 ```php
 // bin/compile.php
 use BEAR\Package\Compiler;
-use MyVendor\MyProject\Injector;
 
 $context = $argv[1] ?? 'prod-app';
+$writeDir = $argv[2] ?? null;
 
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 ```
+
+`Compiler::fromInjector($injector, $context, $writeDir)` is for a caller that already holds an injector - a command inside a running application. It reads one thing from it, the application's `Meta`, and compiles in a child process so classes already in memory cannot narrow the recording. In a build script it would build a container only to throw it away, and on a cold tree that container compiles itself first.
 
 ```json
 "scripts": {
@@ -203,7 +205,7 @@ DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build o
 
 Optional. Use it when the application tree is read-only at runtime and one directory is the only writable location: serverless platforms such as Vercel or AWS Lambda, or a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`. Ordinary VPS and shared hosting do not need it.
 
-Hand that directory to the boot, and to the build. It has to be an absolute path, and the two sides have to agree: the paths are compiled into the DI scripts. Both are enforced - a relative path throws `InvalidWriteDirException`, and a compile whose write directory differs from its injector's throws `WriteDirMismatchException`.
+Hand that directory to the boot, and to the build. It has to be an absolute path, and the two sides have to agree: the paths are compiled into the DI scripts. Both are enforced - a relative path throws `InvalidWriteDirException`, and a compile whose write directory differs from the injector it was handed throws `WriteDirMismatchException`.
 
 ```diff
  // public/index.php
@@ -211,10 +213,10 @@ Hand that directory to the boot, and to the build. It has to be an absolute path
 +exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
 
  // bin/compile.php               php bin/compile.php prod-app /tmp
--exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+-exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__)))());
 +$writeDir = $argv[2] ?? null;
 +
-+exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());
++exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 
  // src/Bootstrap.php
 -    public function __invoke(string $context, array $globals, array $server): int
@@ -224,15 +226,24 @@ Hand that directory to the boot, and to the build. It has to be an absolute path
 +        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
 
  // src/Injector.php
--    public static function getInstance(string $context): InjectorInterface
+-use BEAR\Package\Injector\PackageInjector;
++use BEAR\Package\Injector as PackageInjector;
+
+-    public static function getInstance(string $context, string|null $tmpDir = null, string|null $logDir = null): InjectorInterface
+-    {
+-        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
+-        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
+-        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
+-
+-        return PackageInjector::getInstance($meta, $context, $cache);
+-    }
 +    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
-     {
--        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
++    {
 +        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
-     }
++    }
 ```
 
-Development entry points pass nothing and keep the default paths. Reading environment variables is the entry point's business, not the framework's.
+`BEAR\Package\Injector` builds the `Meta` and the injector cache pool from the write directory, so the skeleton's own `Meta` / `LocalCacheProvider` lines go away. Development entry points pass nothing and keep the default paths. Reading environment variables is the entry point's business, not the framework's.
 
 With `/tmp` as the write directory:
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -220,7 +220,9 @@ Hand that directory to the boot, and to the build. It has to be an absolute path
 
  // src/Bootstrap.php
 -    public function __invoke(string $context, array $globals, array $server): int
-+    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
++    public function __invoke(
++        string $context, array $globals, array $server, string|null $writeDir = null
++    ): int
      {
 -        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
 +        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
@@ -229,7 +231,9 @@ Hand that directory to the boot, and to the build. It has to be an absolute path
 -use BEAR\Package\Injector\PackageInjector;
 +use BEAR\Package\Injector as PackageInjector;
 
--    public static function getInstance(string $context, string|null $tmpDir = null, string|null $logDir = null): InjectorInterface
+-    public static function getInstance(
+-        string $context, string|null $tmpDir = null, string|null $logDir = null
+-    ): InjectorInterface
 -    {
 -        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
 -        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -168,8 +168,11 @@ When setting up, you can **warm up** the project: create static cache files for 
 A build script names the application; it does not boot it (BEAR.Package 1.22+; the skeleton ships `bin/compile.php`).
 
 ```php
+<?php
 // bin/compile.php
 use BEAR\Package\Compiler;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 $context = $argv[1] ?? 'prod-app';
 $writeDir = $argv[2] ?? null;
@@ -197,7 +200,7 @@ mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 
-DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build output: the deployment artifact carries them and runtime only reads them.
+DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build output: when the artifact carries them, runtime reads them instead of compiling.
 
 `vendor/bin/bear.compile` is deprecated. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
 
@@ -248,6 +251,15 @@ Hand that directory to the boot, and to the build. It has to be an absolute path
 ```
 
 `BEAR\Package\Injector` builds the `Meta` and the injector cache pool from the write directory, so the skeleton's own `Meta` / `LocalCacheProvider` lines go away. Development entry points pass nothing and keep the default paths. Reading environment variables is the entry point's business, not the framework's.
+
+The build takes the directory as an argument, the runtime as an environment variable:
+
+```text
+build     php bin/compile.php prod-app /tmp
+runtime   APP_WRITE_DIR=/tmp
+          php-fpm   env[APP_WRITE_DIR] = /tmp
+          docker    --env APP_WRITE_DIR=/tmp
+```
 
 With `/tmp` as the write directory:
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -206,9 +206,14 @@ DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build o
 
 #### Read-only deployments (serverless, immutable containers) {#writable-paths}
 
-Serverless platforms and immutable containers restrict where an application may write. On Vercel or AWS Lambda, or in a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`, the application tree is read-only and one directory - `/tmp`, typically - is the only writable location. Ordinary VPS and shared hosting are unaffected.
+Serverless platforms and immutable containers restrict where an application may write. On Vercel or AWS Lambda, or in a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`, the project directory is read-only and one directory - `/tmp`, typically - is the only writable location. Ordinary VPS and shared hosting are unaffected.
 
-Hand that directory to the boot, and to the build. It has to be an absolute path, and the two sides have to agree: the paths are compiled into the DI scripts. Both are enforced - a relative path throws `InvalidWriteDirException`, and a compile whose write directory differs from the injector it was handed throws `WriteDirMismatchException`.
+Tell the application which directory it may write to. Pass the same directory to both the build and the boot, and keep to two rules:
+
+* Pass an absolute path. A relative path throws `InvalidWriteDirException`.
+* Pass the same path to the build and the boot. The paths are compiled into the DI scripts, so a compile whose write directory differs from the injector it was handed throws `WriteDirMismatchException`.
+
+`$writeDir` is the optional last argument on `Bootstrap::__invoke()`, `Injector::getInstance()` and `new Compiler()`. Change the entry points like this:
 
 ```diff
  // public/index.php
@@ -261,7 +266,7 @@ runtime   APP_WRITE_DIR=/tmp
           docker    --env APP_WRITE_DIR=/tmp
 ```
 
-With `/tmp` as the write directory:
+With `/tmp` as the write directory, the layout is:
 
 ```text
 {appDir}/var/tmp/{context}/di                   compiled DI scripts, in the artifact
@@ -269,9 +274,11 @@ With `/tmp` as the write directory:
 /tmp/MyVendor/MyProject/{context}/log
 ```
 
-The application and the context are in the path because a deploy knows neither, and local cache keys are resource URIs: two applications or two contexts in one directory would answer with each other's entries. Compiled scripts stay under `appDir` - a new instance starts with an empty `/tmp`, so following the write directory would compile again on every cold start (0.38s against 0.018s on a five-resource application).
+The application and the context are in the path because local cache keys are resource URIs: two applications or two contexts sharing one directory would answer with each other's entries.
 
-Boot with a different write directory than the build used and the boot recompiles instead of using the old paths: loudly if the artifact is read-only, with a `Compiled DI scripts on demand` notice otherwise.
+Compiled DI scripts stay under `appDir` and ship inside the artifact. A new instance starts with an empty `/tmp`, so following the write directory would compile again on every cold start - 0.38s against 0.018s on a five-resource application.
+
+If the boot is given a different write directory than the build used, the DI scripts are compiled again instead of read from the old paths: the compile fails if the artifact is read-only, and emits a `Compiled DI scripts on demand` notice if it is writable.
 
 Requires BEAR.Package 1.22+. Background: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491).
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -201,7 +201,7 @@ DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build o
 
 `vendor/bin/bear.compile` is deprecated. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
 
-#### Read-only deployments (serverless, immutable containers) {: #writable-paths }
+#### Read-only deployments (serverless, immutable containers) {#writable-paths}
 
 Optional. Use it when the application tree is read-only at runtime and one directory is the only writable location: serverless platforms such as Vercel or AWS Lambda, or a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`. Ordinary VPS and shared hosting do not need it.
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -180,7 +180,7 @@ $writeDir = $argv[2] ?? null;
 exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 ```
 
-`Compiler::fromInjector($injector, $context, $writeDir)` is for a caller that already holds an injector - a command inside a running application. It reads one thing from it, the application's `Meta`, and compiles in a child process so classes already in memory cannot narrow the recording. In a build script it would build a container only to throw it away, and on a cold tree that container compiles itself first.
+`Compiler::fromInjector($injector, $context, $writeDir)` is for a caller that already holds an injector - a command inside a running application. A build script does not use it.
 
 ```json
 "scripts": {
@@ -206,7 +206,7 @@ DI scripts are written under `{appDir}/var/tmp/{context}/di`. They are a build o
 
 #### Read-only deployments (serverless, immutable containers) {#writable-paths}
 
-Optional. Use it when the application tree is read-only at runtime and one directory is the only writable location: serverless platforms such as Vercel or AWS Lambda, or a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`. Ordinary VPS and shared hosting do not need it.
+Serverless platforms and immutable containers restrict where an application may write. On Vercel or AWS Lambda, or in a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`, the application tree is read-only and one directory - `/tmp`, typically - is the only writable location. Ordinary VPS and shared hosting are unaffected.
 
 Hand that directory to the boot, and to the build. It has to be an absolute path, and the two sides have to agree: the paths are compiled into the DI scripts. Both are enforced - a relative path throws `InvalidWriteDirException`, and a compile whose write directory differs from the injector it was handed throws `WriteDirMismatchException`.
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -160,17 +160,19 @@ final class MyProdLoggerModule extends AbstractModule
 
 セットアップ時にプロジェクトを**ウォームアップ**できます。DI/AOP 用の動的ファイルやアノテーションなどの静的キャッシュを事前に作成し、最適化された `autoload.php` と `preload.php` を出力します。
 
-推奨は、ランタイムと同じアプリ `Injector` を使う `Compiler::fromInjector()` です（BEAR.Package 1.21+。スケルトンは `bin/compile.php`）。
+ビルドスクリプトはアプリケーションを**名乗るだけ**で、起動はしません（BEAR.Package 1.22+。スケルトンは `bin/compile.php`）。
 
 ```php
 // bin/compile.php
 use BEAR\Package\Compiler;
-use MyVendor\MyProject\Injector;
 
 $context = $argv[1] ?? 'prod-app';
+$writeDir = $argv[2] ?? null;
 
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 ```
+
+`Compiler::fromInjector($injector, $context, $writeDir)` は、すでに injector を持っている呼び出し元（動作中のアプリ内のコマンドなど）のためのものです。injector から読むのはアプリの `Meta` 1 つだけで、メモリ上のクラスが記録を狭めないよう子プロセスでコンパイルします。ビルドスクリプトで使うと、捨てるためのコンテナを組むことになり、scripts が無い初回はそのコンテナ自身が先にコンパイルを走らせます。
 
 ```json
 "scripts": {
@@ -196,7 +198,7 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 
 任意です。実行時にアプリのツリーが読み取り専用で、書き込めるのが 1 つのディレクトリだけの環境で使います。Vercel や AWS Lambda などのサーバーレス、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナが該当します。通常の VPS や共有ホストでは不要です。
 
-そのディレクトリを boot と build の両方に渡します。絶対パスであること、そして両者が一致していることが必要です（パスは DI スクリプトに焼き込まれるため）。どちらも強制されます — 相対パスは `InvalidWriteDirException`、injector と compile の書き込み先が違う場合は `WriteDirMismatchException` になります。
+そのディレクトリを boot と build の両方に渡します。絶対パスであること、そして両者が一致していることが必要です（パスは DI スクリプトに焼き込まれるため）。どちらも強制されます — 相対パスは `InvalidWriteDirException`、渡された injector と compile の書き込み先が違う場合は `WriteDirMismatchException` になります。
 
 ```diff
  // public/index.php
@@ -204,10 +206,10 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 +exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
 
  // bin/compile.php               php bin/compile.php prod-app /tmp
--exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+-exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__)))());
 +$writeDir = $argv[2] ?? null;
 +
-+exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());
++exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 
  // src/Bootstrap.php
 -    public function __invoke(string $context, array $globals, array $server): int
@@ -217,15 +219,24 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 +        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
 
  // src/Injector.php
--    public static function getInstance(string $context): InjectorInterface
+-use BEAR\Package\Injector\PackageInjector;
++use BEAR\Package\Injector as PackageInjector;
+
+-    public static function getInstance(string $context, string|null $tmpDir = null, string|null $logDir = null): InjectorInterface
+-    {
+-        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
+-        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
+-        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
+-
+-        return PackageInjector::getInstance($meta, $context, $cache);
+-    }
 +    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
-     {
--        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
++    {
 +        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
-     }
++    }
 ```
 
-開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
+`Meta` と injector のキャッシュプールは書き込み先から `BEAR\Package\Injector` が組むので、スケルトン側の `Meta` / `LocalCacheProvider` の行はなくなります。開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
 
 書き込み先を `/tmp` にした場合:
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -175,7 +175,7 @@ $writeDir = $argv[2] ?? null;
 exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 ```
 
-`Compiler::fromInjector($injector, $context, $writeDir)` は、すでに injector を持っている呼び出し元（動作中のアプリ内のコマンドなど）のためのものです。injector から読むのはアプリの `Meta` 1 つだけで、メモリ上のクラスが記録を狭めないよう子プロセスでコンパイルします。ビルドスクリプトで使うと、捨てるためのコンテナを組むことになり、scripts が無い初回はそのコンテナ自身が先にコンパイルを走らせます。
+`Compiler::fromInjector($injector, $context, $writeDir)` は、すでに injector を持っている呼び出し元（動作中のアプリ内のコマンドなど）のためのものです。ビルドスクリプトでは使いません。
 
 ```json
 "scripts": {
@@ -199,7 +199,7 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 
 #### 読み取り専用デプロイ（サーバーレス / イミュータブルコンテナ） {#writable-paths}
 
-任意です。実行時にアプリのツリーが読み取り専用で、書き込めるのが 1 つのディレクトリだけの環境で使います。Vercel や AWS Lambda などのサーバーレス、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナが該当します。通常の VPS や共有ホストでは不要です。
+サーバーレスやイミュータブルコンテナでは、書き込めるディレクトリが制限されていることがあります。Vercel や AWS Lambda、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナでは、アプリのツリーは読み取り専用で、書き込めるのは `/tmp` など 1 つのディレクトリだけです。通常の VPS や共有ホストでは関係ありません。
 
 そのディレクトリを boot と build の両方に渡します。絶対パスであること、そして両者が一致していることが必要です（パスは DI スクリプトに焼き込まれるため）。どちらも強制されます — 相対パスは `InvalidWriteDirException`、渡された injector と compile の書き込み先が違う場合は `WriteDirMismatchException` になります。
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -160,7 +160,7 @@ final class MyProdLoggerModule extends AbstractModule
 
 セットアップ時にプロジェクトを**ウォームアップ**できます。DI/AOP 用の動的ファイルやアノテーションなどの静的キャッシュを事前に作成し、最適化された `autoload.php` と `preload.php` を出力します。
 
-ビルドスクリプトはアプリケーションを**名乗るだけ**で、起動はしません（BEAR.Package 1.22+。スケルトンは `bin/compile.php`）。
+ビルドスクリプトはアプリケーションを**名乗るだけ**で、起動はしません（BEAR.Package 1.22以降。スケルトンは`bin/compile.php`）。
 
 ```php
 <?php
@@ -175,7 +175,7 @@ $writeDir = $argv[2] ?? null;
 exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
 ```
 
-`Compiler::fromInjector($injector, $context, $writeDir)` は、すでに injector を持っている呼び出し元（動作中のアプリ内のコマンドなど）のためのものです。ビルドスクリプトでは使いません。
+`Compiler::fromInjector($injector, $context, $writeDir)`は、すでにinjectorを持っている呼び出し元（動作中のアプリケーション内のコマンドなど）のためのものです。ビルドスクリプトでは使いません。
 
 ```json
 "scripts": {
@@ -193,15 +193,20 @@ mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 
-DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。これはビルド成果物で、成果物に同梱されていれば実行時はコンパイルせず読むだけです。
+DIスクリプトの出力先は`{appDir}/var/tmp/{context}/di`です。これはビルド成果物で、成果物に同梱されていれば実行時はコンパイルせず読むだけです。
 
 `vendor/bin/bear.compile` は非推奨です。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
 
-#### 読み取り専用デプロイ（サーバーレス / イミュータブルコンテナ） {#writable-paths}
+#### 読み取り専用デプロイ（サーバーレス、イミュータブルコンテナ） {#writable-paths}
 
-サーバーレスやイミュータブルコンテナでは、書き込めるディレクトリが制限されていることがあります。Vercel や AWS Lambda、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナでは、アプリのツリーは読み取り専用で、書き込めるのは `/tmp` など 1 つのディレクトリだけです。通常の VPS や共有ホストでは関係ありません。
+サーバーレスやイミュータブルコンテナでは書き込めるディレクトリが制限されることがあります。VercelやAWS Lambda、`docker run --read-only`や`readOnlyRootFilesystem: true`で起動したコンテナでは、プロジェクトのディレクトリは読み取り専用で、書き込めるのは`/tmp`など1つのディレクトリだけです。通常のVPSや共有ホストでは不要です。
 
-そのディレクトリを boot と build の両方に渡します。絶対パスであること、そして両者が一致していることが必要です（パスは DI スクリプトに焼き込まれるため）。どちらも強制されます — 相対パスは `InvalidWriteDirException`、渡された injector と compile の書き込み先が違う場合は `WriteDirMismatchException` になります。
+この場合は書き込めるディレクトリをアプリケーションに渡します。ビルド時と起動時の両方に渡し、次の2つを守ります。
+
+* 絶対パスを渡します。相対パスを渡すと`InvalidWriteDirException`が投げられます。
+* ビルドと起動で同じパスを渡します。パスはDIスクリプトに焼き込まれるため、渡されたinjectorとコンパイルの書き込み先が違う場合は`WriteDirMismatchException`が投げられます。
+
+`$writeDir`は`Bootstrap::__invoke()`、`Injector::getInstance()`、`new Compiler()`の末尾の省略可能な引数です。エントリポイントを次のように変更します。
 
 ```diff
  // public/index.php
@@ -243,9 +248,9 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 +    }
 ```
 
-`Meta` と injector のキャッシュプールは書き込み先から `BEAR\Package\Injector` が組むので、スケルトン側の `Meta` / `LocalCacheProvider` の行はなくなります。開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
+`Meta`とinjectorのキャッシュプールは書き込み先から`BEAR\Package\Injector`が組むので、スケルトン側の`Meta`/`LocalCacheProvider`の行はなくなります。開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
 
-build にはディレクトリを引数で、実行時には環境変数で渡します。
+書き込み先はビルドには引数で、実行時には環境変数で渡します。
 
 ```text
 build     php bin/compile.php prod-app /tmp
@@ -254,19 +259,21 @@ runtime   APP_WRITE_DIR=/tmp
           docker    --env APP_WRITE_DIR=/tmp
 ```
 
-書き込み先を `/tmp` にした場合:
+書き込み先を`/tmp`にした場合の配置は次のとおりです。
 
 ```text
-{appDir}/var/tmp/{context}/di                   コンパイル済み DI スクリプト（成果物内）
-/tmp/MyVendor/MyProject/{context}/tmp           クエリリポジトリのキャッシュ、serialize した injector
+{appDir}/var/tmp/{context}/di                   コンパイル済みDIスクリプト（成果物内）
+/tmp/MyVendor/MyProject/{context}/tmp           クエリリポジトリのキャッシュ、serializeしたinjector
 /tmp/MyVendor/MyProject/{context}/log
 ```
 
-パスにアプリ名と context が入るのは、デプロイがそのどちらも知らないからです。ローカルキャッシュのキーはリソース URI なので、2 つのアプリや 2 つの context が同じディレクトリを共有すると互いのエントリで応答してしまいます。コンパイル済みスクリプトは `appDir` 配下に残ります。新しいインスタンスの `/tmp` は空なので、書き込み先に追従させると cold start ごとに再コンパイルになるためです（リソース 5 個のアプリで 0.38 秒、成果物から読めば 0.018 秒）。
+パスにアプリケーション名とcontextが入るのは、ローカルキャッシュのキーがリソースURIだからです。区切りがないまま2つのアプリケーションや2つのcontextが同じディレクトリを共有すると、互いのキャッシュエントリで応答してしまいます。
 
-build と違う書き込み先で boot した場合は、古いパスを使うのではなく再コンパイルに落ちます。成果物が読み取り専用なら例外で止まり、書き込み可能なら `Compiled DI scripts on demand` の notice が出ます。
+コンパイル済みDIスクリプトは`appDir`配下に残り、デプロイ成果物に同梱されます。新しいインスタンスの`/tmp`は空なので、DIスクリプトまで書き込み先に移すとコールドスタートのたびに再コンパイルになります（リソース5個のアプリケーションで、再コンパイルが0.38秒、成果物からの読み込みが0.018秒）。
 
-BEAR.Package 1.22 以降が必要です。背景: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491)
+ビルドと違う書き込み先で起動した場合は、古いパスを使わずに再コンパイルされます。成果物が読み取り専用なら例外で止まり、書き込み可能なら`Compiled DI scripts on demand`のnoticeが出ます。
+
+BEAR.Package 1.22以降が必要です。背景: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491)
 
 ### autoload.php
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -213,7 +213,9 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 
  // src/Bootstrap.php
 -    public function __invoke(string $context, array $globals, array $server): int
-+    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
++    public function __invoke(
++        string $context, array $globals, array $server, string|null $writeDir = null
++    ): int
      {
 -        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
 +        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
@@ -222,7 +224,9 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 -use BEAR\Package\Injector\PackageInjector;
 +use BEAR\Package\Injector as PackageInjector;
 
--    public static function getInstance(string $context, string|null $tmpDir = null, string|null $logDir = null): InjectorInterface
+-    public static function getInstance(
+-        string $context, string|null $tmpDir = null, string|null $logDir = null
+-    ): InjectorInterface
 -    {
 -        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
 -        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -163,8 +163,11 @@ final class MyProdLoggerModule extends AbstractModule
 ビルドスクリプトはアプリケーションを**名乗るだけ**で、起動はしません（BEAR.Package 1.22+。スケルトンは `bin/compile.php`）。
 
 ```php
+<?php
 // bin/compile.php
 use BEAR\Package\Compiler;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 $context = $argv[1] ?? 'prod-app';
 $writeDir = $argv[2] ?? null;
@@ -190,7 +193,7 @@ mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 
-DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。これはビルド成果物で、デプロイ成果物に同梱され実行時は読むだけです。
+DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。これはビルド成果物で、成果物に同梱されていれば実行時はコンパイルせず読むだけです。
 
 `vendor/bin/bear.compile` は非推奨です。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
 
@@ -241,6 +244,15 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 ```
 
 `Meta` と injector のキャッシュプールは書き込み先から `BEAR\Package\Injector` が組むので、スケルトン側の `Meta` / `LocalCacheProvider` の行はなくなります。開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
+
+build にはディレクトリを引数で、実行時には環境変数で渡します。
+
+```text
+build     php bin/compile.php prod-app /tmp
+runtime   APP_WRITE_DIR=/tmp
+          php-fpm   env[APP_WRITE_DIR] = /tmp
+          docker    --env APP_WRITE_DIR=/tmp
+```
 
 書き込み先を `/tmp` にした場合:
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -194,7 +194,7 @@ DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。こ�
 
 `vendor/bin/bear.compile` は非推奨です。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
 
-#### 読み取り専用デプロイ（サーバーレス / イミュータブルコンテナ） {: #writable-paths }
+#### 読み取り専用デプロイ（サーバーレス / イミュータブルコンテナ） {#writable-paths}
 
 任意です。実行時にアプリのツリーが読み取り専用で、書き込めるのが 1 つのディレクトリだけの環境で使います。Vercel や AWS Lambda などのサーバーレス、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナが該当します。通常の VPS や共有ホストでは不要です。
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -188,19 +188,58 @@ mv preload.php api.preload.php
 php bin/compile.php prod-html-app
 ```
 
-DI スクリプトの出力先は `{tmpDir}/di` です（既定の `tmpDir` は `var/tmp/{context}`）。ほとんどのデプロイではこの既定のままで問題ありません。
+DI スクリプトの出力先は `{appDir}/var/tmp/{context}/di` です。これはビルド成果物で、デプロイ成果物に同梱され実行時は読むだけです。
 
 `vendor/bin/bear.compile` は非推奨です。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
 
-#### 書き込み先を変える場合 {: #writable-paths }
+#### 読み取り専用デプロイ（サーバーレス / イミュータブルコンテナ） {: #writable-paths }
 
-プロジェクトツリー外に一時ファイルやログを置きたいときだけ使います（任意）。例としては、アプリ本体が読み取り専用のホスト（一部の serverless / コンテナ構成）や、ビルド時と実行時で書き込みパスが分かれる場合です。通常の VPS や共有ホストでは不要です。
+任意です。実行時にアプリのツリーが読み取り専用で、書き込めるのが 1 つのディレクトリだけの環境で使います。Vercel や AWS Lambda などのサーバーレス、`docker run --read-only` や `readOnlyRootFilesystem: true` で起動したコンテナが該当します。通常の VPS や共有ホストでは不要です。
 
-`Meta` のコンストラクタに解決済みのパスを渡せます（環境変数の解釈はアプリ側の都合です）。`Compiler::fromInjector()` ならコンパイルも同じ Meta を使います。
+そのディレクトリを boot と build の両方に渡します。絶対パスであること、そして両者が一致していることが必要です（パスは DI スクリプトに焼き込まれるため）。どちらも強制されます — 相対パスは `InvalidWriteDirException`、injector と compile の書き込み先が違う場合は `WriteDirMismatchException` になります。
 
-```php
-new Meta($name, $context, $appDir, '/var/tmp/my-app', '/var/log/my-app');
+```diff
+ // public/index.php
+-exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER));
++exit((new Bootstrap())('prod-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
+
+ // bin/compile.php               php bin/compile.php prod-app /tmp
+-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
++$writeDir = $argv[2] ?? null;
++
++exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());
+
+ // src/Bootstrap.php
+-    public function __invoke(string $context, array $globals, array $server): int
++    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
+     {
+-        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
++        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
+
+ // src/Injector.php
+-    public static function getInstance(string $context): InjectorInterface
++    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
+     {
+-        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
++        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
+     }
 ```
+
+開発用のエントリは何も渡さず既定のパスを使います。環境変数を読むのはエントリの仕事で、フレームワークの仕事ではありません。
+
+書き込み先を `/tmp` にした場合:
+
+```text
+{appDir}/var/tmp/{context}/di                   コンパイル済み DI スクリプト（成果物内）
+/tmp/MyVendor/MyProject/{context}/tmp           クエリリポジトリのキャッシュ、serialize した injector
+/tmp/MyVendor/MyProject/{context}/log
+```
+
+パスにアプリ名と context が入るのは、デプロイがそのどちらも知らないからです。ローカルキャッシュのキーはリソース URI なので、2 つのアプリや 2 つの context が同じディレクトリを共有すると互いのエントリで応答してしまいます。コンパイル済みスクリプトは `appDir` 配下に残ります。新しいインスタンスの `/tmp` は空なので、書き込み先に追従させると cold start ごとに再コンパイルになるためです（リソース 5 個のアプリで 0.38 秒、成果物から読めば 0.018 秒）。
+
+build と違う書き込み先で boot した場合は、古いパスを使うのではなく再コンパイルに落ちます。成果物が読み取り専用なら例外で止まり、書き込み可能なら `Compiled DI scripts on demand` の notice が出ます。
+
+BEAR.Package 1.22 以降が必要です。背景: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491)
 
 ### autoload.php
 


### PR DESCRIPTION
Documents what [BEAR.Package 1.22.0](https://github.com/bearsunday/BEAR.Package/releases/tag/1.22.0) shipped. `manuals/1.0/{en,ja}/production.md` only.

## Compilation

The recommended build entry no longer boots the application:

```diff
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+$writeDir = $argv[2] ?? null;
+exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__), $writeDir))());
```

`fromInjector()` reads one thing from the injector it is handed - the application's `Meta` - so a build script that calls it builds a container only to throw it away, and on a cold tree that container compiles itself first. It stays documented for what it is for: a command inside a running application.

`preload.php` is now recorded by a worker that boots the finished artifact, so the compile no longer needs the injector to measure it.

## Read-only deployments

A new section for the case the previous "Changing writable paths" text only gestured at: the application tree is read-only at runtime and one directory is the only writable location - Vercel, AWS Lambda, `docker run --read-only`. It gives the four files as a diff (`public/index.php`, `bin/compile.php`, `src/Bootstrap.php`, `src/Injector.php`), the `{writeDir}/{Vendor}/{Project}/{context}/{tmp,log}` layout, and the two rules the framework enforces rather than documents (absolute path, build and boot agree).

It also says what does **not** move: compiled DI scripts stay under `appDir`, where the deployment artifact carries them. A new instance starts with an empty `/tmp`, so following the write directory would compile again on every cold start.

## The anchor was never live

`#### … {: #writable-paths }` is not kramdown - a span IAL on the same line as a heading is ignored, and the id becomes a slug of the whole line:

```
$ printf '#### Changing writable paths {: #writable-paths }\n' | kramdown
Warning: Found span IAL after text - ignoring it
<h4 id="changing-writable-paths--writable-paths-">Changing writable paths {: #writable-paths }</h4>
```

The published page shows the braces in the heading, and every link to `#writable-paths` lands at the top of the page. `{#writable-paths}` gives `<h4 id="writable-paths">`. The 1.22.0 release notes link to that anchor.

## Not in this PR

- `MyVendor.Ticket` still requires `bear/package ^1.21` and its `bin/compile.php` uses `fromInjector()`. It needs the constructor entry, `^1.22`, and a regenerated lock - a separate PR.
- #386 rewrites the same Compilation section on the premise that `fromInjector()` is the recommended entry. Its `.compile.php` findings still hold; the framing needs a pass on top of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 読み取り専用デプロイに対応し、ビルド時・起動時の書き込み先を指定できるようになりました。
  - キャッシュ、ログ、一時データなどの保存先を任意の絶対パスに設定できます。
  - 書き込み先の不一致や相対パスを検出し、エラーを表示します。
  - 設定変更時には必要に応じて成果物を自動的に再生成します。

- **ドキュメント**
  - コンパイル手順、成果物の配置場所、設定例を更新しました。
  - 既存のコンパイル方法に関する非推奨案内を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->