### PR TITLE
Document compilation, Phar and read-only deployment; restructure the production page

### DIFF
--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -54,7 +54,6 @@ What you add to this module, depending on the deployment environment, is the res
 * [Cache version](#cache-version) — discard the cache when the resource schema changes
 * [Resource execution log](#logging)
 * [Per-error log files](#error-log)
-* [Error log servers](#error-log-server) — a logger binding that keeps 4xx noise away
 * [Declaring where the application writes](#writable-paths) — required on serverless and read-only containers
 
 ## Cache {#cache}
@@ -135,37 +134,7 @@ The `__invoke` method of [LoggerInterface](https://github.com/bearsunday/BEAR.Re
 
 ### Error Logs {#error-log}
 
-An uncaught exception goes to the logger bound to `Psr\Log\LoggerInterface` — with no logger of your own bound, that is PHP's `error_log`. The log level follows the same criteria as the error page: client-caused (the `BadRequestException` family, 4xx) logs at debug, server faults (5xx) at error.
-
-A server fault responds with a `logref` ID, and the same ID is recorded in the log. By default a `logref.{id}.log` file is also written under `var/log/{context}`, with `last.logref.log` linking to the newest one. `ProdModule` binds `NullLogRefWriter` instead, so production writes no file; to keep the per-error files, bind `LogRefWriterInterface` to `FileLogRefWriter`. The file is written on the server that handled the request.
-
-### Error log servers {#error-log-server}
-
-To use an error log server such as Sentry, bind a logger to `LoggerInterface` whose server handler sends only error and above. 4xx logs at debug, so 404/405 scan noise does not arrive.
-
-```php
-$this->bind(LoggerInterface::class)->toProvider(AppLoggerProvider::class)->in(Scope::SINGLETON);
-```
-
-Build Monolog in the provider and give only the error-log-server handler a `Level::Error` threshold. Resolve the DSN at runtime — do not bake it in at [compile time](#compilation-recommended).
-
-### Domain exceptions {#domain-exceptions}
-
-The same criteria classify the application's own exceptions. A client-caused exception extends `BadRequestException` and specifies its HTTP code in the constructor. That alone decides the error page status code, the log level, and whether the exception is sent to the error log server.
-
-```php
-use BEAR\Resource\Exception\BadRequestException;
-
-final class CartExpired extends BadRequestException
-{
-    public function __construct(string $cartId)
-    {
-        parent::__construct($cartId, 410);
-    }
-}
-```
-
-A 410 Gone page returns and the log is debug. An exception that does not extend `BadRequestException` is treated as a server fault (`RuntimeException` family: 503, everything else: 500 — logged at error).
+An uncaught error responds with a `logref` ID, and the rendered exception goes to the logger bound to `Psr\Log\LoggerInterface` — with no logger of your own bound, that is PHP's `error_log`. By default a `logref.{id}.log` file is also written under `var/log/{context}`, with `last.logref.log` linking to the newest one. `ProdModule` binds `NullLogRefWriter` instead, so production writes no file; to keep the per-error files, bind `LogRefWriterInterface` to `FileLogRefWriter` in your `ProdModule`.
 
 ## Deployment
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -54,6 +54,7 @@ What you add to this module, depending on the deployment environment, is the res
 * [Cache version](#cache-version) — discard the cache when the resource schema changes
 * [Resource execution log](#logging)
 * [Per-error log files](#error-log)
+* [Error log servers](#error-log-server) — a logger binding that keeps 4xx noise away
 * [Declaring where the application writes](#writable-paths) — required on serverless and read-only containers
 
 ## Cache {#cache}
@@ -134,7 +135,37 @@ The `__invoke` method of [LoggerInterface](https://github.com/bearsunday/BEAR.Re
 
 ### Error Logs {#error-log}
 
-An uncaught error responds with a `logref` ID, and the rendered exception goes to the logger bound to `Psr\Log\LoggerInterface` — with no logger of your own bound, that is PHP's `error_log`. By default a `logref.{id}.log` file is also written under `var/log/{context}`, with `last.logref.log` linking to the newest one. `ProdModule` binds `NullLogRefWriter` instead, so production writes no file; to keep the per-error files, bind `LogRefWriterInterface` to `FileLogRefWriter` in your `ProdModule`.
+An uncaught exception goes to the logger bound to `Psr\Log\LoggerInterface` — with no logger of your own bound, that is PHP's `error_log`. The log level follows the same criteria as the error page: client-caused (the `BadRequestException` family, 4xx) logs at debug, server faults (5xx) at error.
+
+A server fault responds with a `logref` ID, and the same ID is recorded in the log. By default a `logref.{id}.log` file is also written under `var/log/{context}`, with `last.logref.log` linking to the newest one. `ProdModule` binds `NullLogRefWriter` instead, so production writes no file; to keep the per-error files, bind `LogRefWriterInterface` to `FileLogRefWriter`. The file is written on the server that handled the request.
+
+### Error log servers {#error-log-server}
+
+To use an error log server such as Sentry, bind a logger to `LoggerInterface` whose server handler sends only error and above. 4xx logs at debug, so 404/405 scan noise does not arrive.
+
+```php
+$this->bind(LoggerInterface::class)->toProvider(AppLoggerProvider::class)->in(Scope::SINGLETON);
+```
+
+Build Monolog in the provider and give only the error-log-server handler a `Level::Error` threshold. Resolve the DSN at runtime — do not bake it in at [compile time](#compilation-recommended).
+
+### Domain exceptions {#domain-exceptions}
+
+The same criteria classify the application's own exceptions. A client-caused exception extends `BadRequestException` and specifies its HTTP code in the constructor. That alone decides the error page status code, the log level, and whether the exception is sent to the error log server.
+
+```php
+use BEAR\Resource\Exception\BadRequestException;
+
+final class CartExpired extends BadRequestException
+{
+    public function __construct(string $cartId)
+    {
+        parent::__construct($cartId, 410);
+    }
+}
+```
+
+A 410 Gone page returns and the log is debug. An exception that does not extend `BadRequestException` is treated as a server fault (`RuntimeException` family: 503, everything else: 500 — logged at error).
 
 ## Deployment
 

--- a/manuals/1.0/en/production.md
+++ b/manuals/1.0/en/production.md
@@ -15,31 +15,30 @@ The default `prod` binding binds the following interfaces:
 * Error page generation factory
 * PSR logger interface
 * Local cache
-* Distributed cache
+* Resource cache (query repository)
 
-See [ProdModule.php](https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Context/ProdModule.php) in BEAR.Package for details.
+The OPTIONS method is also disabled. See [ProdModule.php](https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Context/ProdModule.php) in BEAR.Package for details.
 
 ## Application's ProdModule
 
-Customize the application's `ProdModule` in `src/Module/ProdModule.php` against the default ProdModule. Error pages and distributed caches are particularly important.
+Customize the application's `ProdModule` in `src/Module/ProdModule.php` against the default ProdModule.
 
 ```php
 <?php
-namespace MyVendor\Todo\Module;
+
+namespace MyVendor\MyProject\Module;
 
 use BEAR\Package\Context\ProdModule as PackageProdModule;
+use BEAR\Package\Provide\Error\ErrorPageFactoryInterface;
 use BEAR\QueryRepository\CacheVersionModule;
 use BEAR\Resource\Module\OptionsMethodModule;
-use BEAR\Package\AbstractAppModule;
+use Ray\Di\AbstractModule;
 
 class ProdModule extends AbstractModule
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
-        $this->install(new PackageProdModule);       // Default prod settings
+        $this->install(new PackageProdModule);       // Default prod binding
         $this->override(new OptionsMethodModule);    // Enable OPTIONS method in production as well
         $this->install(new CacheVersionModule('1')); // Specify resource cache version
 
@@ -49,86 +48,73 @@ class ProdModule extends AbstractModule
 }
 ```
 
-## Cache
+What you add to this module, depending on the deployment environment, is the rest of this page:
+
+* [Distributed cache](#cache) — required with two or more web servers
+* [Cache version](#cache-version) — discard the cache when the resource schema changes
+* [Resource execution log](#logging)
+* [Per-error log files](#error-log)
+* [Declaring where the application writes](#writable-paths) — required on serverless and read-only containers
+
+## Cache {#cache}
 
 There are two types of caches: a local cache and a distributed cache that is shared between multiple web servers.
-Both caches default to [PhpFileCache](https://www.doctrine-project.org/projects/doctrine-cache/en/1.10/index.html#phpfilecache).
 
 ### Local Cache
 
-The local cache is used for caches that do not change after deployment, such as annotations, while the distributed cache is used to store resource states.
+The local cache is used for what does not change after deployment, such as annotations. It is written to [APCu](https://www.php.net/manual/en/book.apcu.php) when available, and to files otherwise.
 
 ### Distributed Cache
 
-To provide services with two or more web servers, a distributed cache configuration is required.
-Modules for each of the popular [memcached](http://php.net/manual/en/book.memcached.php) and [Redis](https://redis.io) cache engines are provided.
+Resource states are stored here. To provide services with two or more web servers, a distributed cache configuration is required. Modules for each of the popular [memcached](https://www.php.net/manual/en/book.memcached.php) and [Redis](https://redis.io) cache engines are provided.
 
-
-### Memcached
+#### Memcached
 
 ```php
-<?php
-namespace BEAR\HelloWorld\Module;
-
-use BEAR\QueryRepository\StorageMemcachedModule;
-use BEAR\Resource\Module\ProdLoggerModule;
-use BEAR\Package\Context\ProdModule as PackageProdModule;
-use BEAR\Package\AbstractAppModule;
-use Ray\Di\Scope;
-
-class ProdModule extends AbstractModule
-{
-    protected function configure()
-    {
-        // memcache
-        // {host}:{port}:{weight},...
-        $memcachedServers = 'mem1.domain.com:11211:33,mem2.domain.com:11211:67';
-        $this->install(new StorageMemcachedModule($memcachedServers));
-
-        // Install Prod logger
-        $this->install(new ProdLoggerModule);
-        // Install default ProdModule
-        $this->install(new PackageProdModule);
-    }
-}
+// {host}:{port}:{weight},...
+$memcachedServers = 'mem1.domain.com:11211:33,mem2.domain.com:11211:67';
+$this->install(new StorageMemcachedModule($memcachedServers));
 ```
 
-### Redis
+#### Redis
 
-
-```php?start_inline
-// redis
+```php
 $redisServer = 'localhost:6379'; // {host}:{port}
 $this->install(new StorageRedisModule($redisServer));
 ```
 
-In addition to simply updating the cache by TTL for storing resource states, it is also possible to operate (CQRS) as a persistent storage that does not disappear after the TTL time.
-In that case, you need to perform persistent processing with `Redis` or prepare your own storage adapter for other KVS such as Cassandra.
+In addition to simply updating the cache by TTL for storing resource states, it is also possible to operate (CQRS) as a persistent storage that does not disappear after the TTL time. In that case, you need to perform persistent processing with `Redis` or prepare your own storage adapter for other KVS such as Cassandra.
 
 ### Specifying Cache Time
 
 To change the default TTL, install `StorageExpiryModule`.
 
-```php?start_inline
+```php
 // Cache time
 $short = 60;
 $medium = 3600;
 $long = 24 * 3600;
 $this->install(new StorageExpiryModule($short, $medium, $long));
 ```
-### Specifying Cache Version
+
+### Specifying Cache Version {#cache-version}
 
 Change the cache version when the resource schema changes and compatibility is lost. This is especially important for CQRS operation that does not disappear over TTL time.
 
-```
+```php
 $this->install(new CacheVersionModule($cacheVersion));
 ```
 
 To discard the resource cache every time you deploy, it is convenient to assign a time or random value to `$cacheVersion` so that no change is required.
 
-## Logging
+## Logging {#logging}
 
 `ProdLoggerModule` is a resource execution log module for production. When installed, it logs requests other than GET to the logger bound to `Psr\Log\LoggerInterface`.
+
+```php
+$this->install(new ProdLoggerModule);
+```
+
 If you want to log on a specific resource or specific state, bind a custom log to [BEAR\Resource\LoggerInterface](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/LoggerInterface.php).
 
 ```php
@@ -144,10 +130,9 @@ final class MyProdLoggerModule extends AbstractModule
 }
 ```
 
-The `__invoke` method of [LoggerInterface](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/LoggerInterface.php) passes the resource URI and resource state as a `ResourceObject` object, so log the necessary parts based on its contents.
-Refer to the [existing implementation ProdLogger](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/ProdLogger.php) for creation.
+The `__invoke` method of [LoggerInterface](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/LoggerInterface.php) passes the resource URI and resource state as a `ResourceObject` object, so log the necessary parts based on its contents. Refer to the [existing implementation ProdLogger](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/ProdLogger.php) for creation.
 
-### Error logs
+### Error Logs {#error-log}
 
 An uncaught error responds with a `logref` ID, and the rendered exception goes to the logger bound to `Psr\Log\LoggerInterface` — with no logger of your own bound, that is PHP's `error_log`. By default a `logref.{id}.log` file is also written under `var/log/{context}`, with `last.logref.log` linking to the newest one. `ProdModule` binds `NullLogRefWriter` instead, so production writes no file; to keep the per-error files, bind `LogRefWriterInterface` to `FileLogRefWriter` in your `ProdModule`.
 
@@ -166,13 +151,13 @@ An uncaught error responds with a `logref` ID, and the rendered exception goes t
 * It is recommended to incorporate compilation into CI as the compiler outputs exit code 1 when it finds dependency issues and 0 when compilation succeeds.
 
 <a id="compilation"></a>
-### Compilation Recommended
+### Compilation {#compilation-recommended}
 
 When setting up, you can **warm up** the project: create static cache files for DI/AOP and annotations in advance, and write optimized `autoload.php` and `preload.php`.
 
 **Principle: compile on the deploy target when you can** (at warm-up / health-check time). Real environment values — paths, environment variables — are reflected as-is, so values bake in correctly.
 
-**Exception: environments that need ahead-of-time compilation** (serverless, a read-only app root, or a fixed path such as `/tmp`). Because you compile where the real services are unreachable, combine [declaring where the application writes](#writable-paths), AOT script reuse, and `.compile.php` (to stub the unreachable services), and **do not bake values that vary at runtime (hosts, tokens) — resolve them at runtime.**
+**Exception: environments that need ahead-of-time compilation** (serverless, a read-only app root, or a fixed path such as `/tmp`). Because you compile where the real services are unreachable, combine [declaring where the application writes](#writable-paths), AOT script reuse, and [`.compile.php`](#compile-php) (to stub the unreachable services), and **do not bake values that vary at runtime (hosts, tokens) — resolve them at runtime.**
 
 A build script names the application; it does not boot it (BEAR.Package 1.22+; the skeleton ships `bin/compile.php`).
 
@@ -201,6 +186,12 @@ The script names the application, the context and the application directory, and
 * If you compile, the possibility of DI errors at runtime is extremely low because injection is performed in all classes.
 * The contents included in `.env` are incorporated into the PHP file, so `.env` can be deleted after compilation.
 
+DI scripts are written under `{appDir}/var/build/{context}/di`. The build directory holds what a compile produced and nothing a request writes, so it can ship read-only: when the artifact carries it, runtime reads the scripts instead of compiling.
+
+`vendor/bin/bear.compile` was removed in BEAR.Package 1.24. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
+
+#### Compiling multiple contexts {#multiple-contexts}
+
 Compiling multiple contexts (e.g. api-app and html-app for content negotiation) is a loop in the script. `autoload.php` and `preload.php` are written to fixed paths and the next compile removes them, so rename them as you go:
 
 ```php
@@ -227,10 +218,6 @@ exit(0);
 
 Packing each context into an archive is a loop of its own, and it does not rename the preload: [Phar](phar.html).
 
-DI scripts are written under `{appDir}/var/build/{context}/di`. The build directory holds what a compile produced and nothing a request writes, so it can ship read-only: when the artifact carries it, runtime reads the scripts instead of compiling.
-
-`vendor/bin/bear.compile` was removed in BEAR.Package 1.24. Migration: [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482).
-
 #### Compile steps {#compile-steps}
 
 A module can bind a compile step — `BEAR\Sunday\Compile\CompileStepInterface` — and the compile runs it. Each step is handed an empty directory of its own under the build directory, named after its binding key, and what it writes ships with the artifact:
@@ -245,7 +232,77 @@ Template engines use this: the first request has nothing left to compile, and no
 
 Requires bear/sunday 1.9+. Background: [BEAR.Package#501](https://github.com/bearsunday/BEAR.Package/pull/501).
 
-#### Read-only deployments (serverless, immutable containers) {#writable-paths}
+#### .compile.php {#compile-php}
+
+When there are classes that cannot be generated in a non-production environment (for example, a ResourceObject that requires successful authentication to complete injection), you can compile them by describing dummy class loading in the root `.compile.php` file, which is only loaded during compilation. **Its purpose is to let construction succeed at compile time, so its contents should be null objects (do-nothing implementations).** This applies not only to ahead-of-time builds (real services unreachable) but also to resources that need per-request state such as authentication, which is absent during compilation even when you compile on the deploy target. Keep value fakes (`$_SERVER['X'] = 'fake'`, etc.) to the minimum needed to pass construction, and never use them for values the runtime needs for real (they bake in).
+
+**Note:** the compiler loads `.compile.php` itself, before it builds the container. The removed `vendor/bin/bear.compile` did too; nothing else has to.
+
+Example) If there is an AuthProvider that throws an exception when authentication cannot be obtained in the constructor, you can create an empty class as follows and load it in .compile.php:
+
+/tests/Null/AuthProvider.php
+```php
+<?php
+class AuthProvider 
+{  // Only for instantiation, so implementation is not required
+}
+```
+
+.compile.php
+```php
+<?php
+require __DIR__ . '/tests/Null/AuthProvider.php'; // Always-generatable Null object
+$_SERVER['YOUR_REQUIRED_ENV'] = 'fake'; // For cases where errors occur without specific environment variables
+```
+
+This allows you to avoid exceptions and perform compilation. Additionally, since Symfony's cache component connects to the cache engine in the constructor, it's good to load a dummy adapter during compilation like this:
+
+tests/Null/RedisAdapter.php
+```php
+namespace Ray\PsrCacheModule;
+
+use Ray\Di\ProviderInterface;
+use Serializable;
+use Symfony\Component\Cache\Adapter\RedisAdapter as OriginAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+class RedisAdapter extends OriginAdapter implements Serializable
+{
+    use SerializableTrait;
+
+    public function __construct(ProviderInterface $redisProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
+    {
+        // do nothing
+    }
+}
+```
+
+#### autoload.php {#autoloadphp}
+
+An optimized autoload file is output to `{project_path}/autoload.php`. It is lighter than the `vendor/autoload.php` produced by `composer dump-autoload --optimize` and reduces per-request autoload cost **when you do not use preload**.
+
+Note: If you use `preload.php`, most classes are already loaded at startup, so this `autoload.php` is essentially unnecessary — use the `vendor/autoload.php` generated by Composer. In other words, `autoload.php` is a fallback for environments that cannot use preload.
+
+#### preload.php {#preloadphp}
+
+An optimized preload.php file is output to `{project_path}/preload.php`. To enable preloading, you need to specify [opcache.preload](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload) and [opcache.preload_user](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload-user) in php.ini.
+
+Example)
+
+```ini
+opcache.preload=/path/to/project/preload.php
+opcache.preload_user=www-data
+```
+
+#### module.dot {#module-dot}
+
+When you compile, a "dot file" is output, so you can convert it to an image file with [graphviz](https://graphviz.org/) or use [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/) to display the object graph. Also, please see the [object graph](/images/screen/skeleton.svg) of the skeleton.
+
+```bash
+dot -T svg module.dot > module.svg
+```
+
+### Read-only deployments (serverless, immutable containers) {#writable-paths}
 
 Serverless platforms and immutable containers restrict where an application may write. On Vercel or AWS Lambda, or in a container started with `docker run --read-only` / `readOnlyRootFilesystem: true`, the project directory is read-only and one directory - `/tmp`, typically - is the only writable location. Ordinary VPS and shared hosting are unaffected.
 
@@ -310,7 +367,7 @@ A single-file artifact that never writes into itself is [Phar](phar.html).
 
 Requires BEAR.Package 1.24+. Background: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491).
 
-#### Docker multi-stage build {#docker-multi-stage}
+### Docker multi-stage build {#docker-multi-stage}
 
 Compilation is build work. A Docker [multi-stage build](https://docs.docker.com/build/building/multi-stage/) pins it to the image build.
 
@@ -329,101 +386,3 @@ COPY --from=build /app /var/www/app
 The image that boots carries the compiled DI scripts, with nothing left to do at boot. A cold start only reads the artifact — 0.38s down to 0.018s in the measurement above — and every instance that scale-out adds boots from the same artifact, so every container gives the same answer. To start the runtime stage with `docker run --read-only`, combine with [declared write locations](#writable-paths).
 
 This is the "environments that need ahead-of-time compilation" exception of [Compilation](#compilation-recommended): values that change at runtime — endpoints, tokens — are not baked in, but resolved at runtime.
-
-### autoload.php
-
-An optimized autoload file is output to `{project_path}/autoload.php`. It is lighter than the `vendor/autoload.php` produced by `composer dump-autoload --optimize` and reduces per-request autoload cost **when you do not use preload**.
-
-Note: If you use `preload.php`, most classes are already loaded at startup, so this `autoload.php` is essentially unnecessary — use the `vendor/autoload.php` generated by Composer. In other words, `autoload.php` is a fallback for environments that cannot use preload.
-
-### preload.php
-
-An optimized preload.php file is output to `{project_path}/preload.php`.
-To enable preloading, you need to specify [opcache.preload](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload) and [opcache.preload](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload-user) in php.ini. It is a feature supported in PHP 7.4, but it is unstable in the initial versions of `7.4`. Let's use the latest version of `7.4.4` or higher.
-
-Example)
-
-```
-opcache.preload=/path/to/project/preload.php
-opcache.preload_user=www-data
-```
-
-Note: Please refer to the [benchmark](https://github.com/bearsunday/BEAR.HelloworldBenchmark/wiki/Intel-Core-i5-3.8-GHz-iMac-(Retina-5K,-27-inch,-2017)---PHP-7.4.4) for performance benchmarks.
-
-
-### .compile.php
-
-When there are classes that cannot be generated in a non-production environment (for example, a ResourceObject that requires successful authentication to complete injection), you can compile them by describing dummy class loading in the root `.compile.php` file, which is only loaded during compilation. **Its purpose is to let construction succeed at compile time, so its contents should be null objects (do-nothing implementations).** This applies not only to ahead-of-time builds (real services unreachable) but also to resources that need per-request state such as authentication, which is absent during compilation even when you compile on the deploy target. Keep value fakes (`$_SERVER['X'] = 'fake'`, etc.) to the minimum needed to pass construction, and never use them for values that must be real at runtime (they get baked in).
-
-**Note:** the compiler loads `.compile.php` itself, before it builds the container. The removed `vendor/bin/bear.compile` did too; nothing else has to.
-
-.compile.php
-
-Example) If there is an AuthProvider that throws an exception when authentication cannot be obtained in the constructor, you can create an empty class as follows and load it in .compile.php:
-
-/tests/Null/AuthProvider.php
-```php
-<?php
-class AuthProvider 
-{  // Only for instantiation, so implementation is not required
-}
-```
-
-.compile.php
-```php
-<?php
-require __DIR__ . '/tests/Null/AuthProvider.php'; // Always-generatable Null object
-$_SERVER['YOUR_REQUIRED_ENV'] = 'fake'; // For cases where errors occur without specific environment variables
-```
-
-This allows you to avoid exceptions and perform compilation. Additionally, since Symfony's cache component connects to the cache engine in the constructor, it's good to load a dummy adapter during compilation like this:
-
-tests/Null/RedisAdapter.php
-```php
-namespace Ray\PsrCacheModule;
-
-use Ray\Di\ProviderInterface;
-use Serializable;
-use Symfony\Component\Cache\Adapter\RedisAdapter as OriginAdapter;
-use Symfony\Component\Cache\Marshaller\MarshallerInterface;
-
-class RedisAdapter extends OriginAdapter implements Serializable
-{
-    use SerializableTrait;
-    
-    public function __construct(ProviderInterface $redisProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
-    {
-    　　// do nothing
-    }
-}
-```
-
-### module.dot
-
-When you compile, a "dot file" is output, so you can convert it to an image file with [graphviz](https://graphviz.org/) or use [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/) to display the object graph.
-Also, please see the [object graph](/images/screen/skeleton.svg) of the skeleton.
-
-```php
-dot -T svn module.dot > module.svg
-```
-
-## Bootstrap Performance Tuning
-
-[immutable_cache](https://pecl.php.net/package/immutable_cache) is a PECL package for caching immutable values in shared memory. It is based on APCu but is faster than APCu because it stores immutable values such as PHP objects and arrays in shared memory. Additionally, installing PECL's [Igbinary](https://www.php.net/manual/en/book.igbinary.php) with either APCu or immutable_cache can reduce memory usage and further improve performance.
-
-Currently, there are no dedicated cache adapters available. Please refer to [ImmutableBootstrap](https://github.com/koriym/BEAR.Hello/commit/507d1ee3ed514686be2d786cdaae1ba8bed63cc4) to create and call a dedicated Bootstrap. This allows you to minimize initialization costs and achieve maximum performance.
-
-### php.ini
-
-```
-// Extensions
-extension="apcu.so"
-extension="immutable_cache.so" 
-extension="igbinary.so"
-
-// Specifying serializer
-apc.serializer=igbinary
-immutable_cache.serializer=igbinary
-```
-
-----

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -55,7 +55,6 @@ class ProdModule extends AbstractModule
 * [キャッシュバージョン](#cache-version) — リソースのスキーマ変更時にキャッシュを破棄
 * [リソース実行ログ](#logging)
 * [エラーログのファイル出力](#error-log)
-* [エラーログサーバー](#error-log-server) — 4xxのノイズを送らないロガー束縛
 * [書き込み先の宣言](#writable-paths) — サーバーレスや読み取り専用コンテナで必要
 
 ## キャッシュ {#cache}
@@ -136,37 +135,7 @@ final class MyProdLoggerModule extends AbstractModule
 
 ### エラーログ {#error-log}
 
-捕捉されなかった例外は`Psr\Log\LoggerInterface`にバインドされたロガーへ送られます（独自のロガーをバインドしていなければPHPの`error_log`）。ログレベルはエラーページと同じ基準で決まります。クライアント起因（`BadRequestException`系、4xx）はdebug、サーバー障害（5xx）はerrorです。
-
-サーバー障害はレスポンスに`logref` IDを付与し、同じIDがログにも記録されます。既定では`var/log/{context}`に`logref.{id}.log`ファイルも書かれ、`last.logref.log`が最新のものを指します。`ProdModule`は代わりに`NullLogRefWriter`をバインドするため、プロダクションではファイルを書きません。エラーごとのファイルを残すには`LogRefWriterInterface`を`FileLogRefWriter`にバインドします。ファイルはリクエストを処理したサーバーに書かれます。
-
-### エラーログサーバー {#error-log-server}
-
-Sentryのようなエラーログサーバーを使う場合は、errorレベル以上だけを送るハンドラを持つロガーを`LoggerInterface`に束縛します。4xxはdebugでログされるため、404や405のスキャンノイズは届きません。
-
-```php
-$this->bind(LoggerInterface::class)->toProvider(AppLoggerProvider::class)->in(Scope::SINGLETON);
-```
-
-プロバイダーでMonologを組み、エラーログサーバーのハンドラだけ閾値を`Level::Error`にします。接続先のDSNはランタイムで解決します（[コンパイル](#compilation-recommended)で焼き込まない）。
-
-### ドメイン例外 {#domain-exceptions}
-
-アプリケーション独自の例外もこの基準で分類されます。クライアント起因の例外は`BadRequestException`を継承し、HTTPコードをコンストラクタで指定します。それだけで、エラーページのステータスコード・ログレベル・エラーログサーバーに送られるかどうかが決まります。
-
-```php
-use BEAR\Resource\Exception\BadRequestException;
-
-final class CartExpired extends BadRequestException
-{
-    public function __construct(string $cartId)
-    {
-        parent::__construct($cartId, 410);
-    }
-}
-```
-
-410 Goneのページが返り、ログはdebugです。`BadRequestException`を継承しない例外はサーバー障害として扱われます（`RuntimeException`系は503、その他は500。ログはerror）。
+捕捉されなかったエラーはレスポンスに`logref` IDを付与し、整形された例外を`Psr\Log\LoggerInterface`にバインドされたロガーへ送ります（独自のロガーをバインドしていなければPHPの`error_log`）。既定では`var/log/{context}`に`logref.{id}.log`ファイルも書かれ、`last.logref.log`が最新のものを指します。`ProdModule`は代わりに`NullLogRefWriter`をバインドするため、プロダクションではファイルを書きません。エラーごとのファイルを残すには、アプリケーションの`ProdModule`で`LogRefWriterInterface`を`FileLogRefWriter`にバインドします。
 
 ## デプロイ
 

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -16,85 +16,70 @@ BEAR.Sundayの既定の`prod`束縛をベースに、アプリケーション側
 * エラーページ生成ファクトリー
 * PSRロガーインターフェース
 * ローカルキャッシュ
-* 分散キャッシュ
+* リソースキャッシュ（クエリーリポジトリー）
 
-詳細はBEAR.Packageの[ProdModule.php](https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Context/ProdModule.php)を参照してください。
+また、OPTIONSメソッドは無効化されます。詳細はBEAR.Packageの[ProdModule.php](https://github.com/bearsunday/BEAR.Package/blob/1.x/src/Context/ProdModule.php)を参照してください。
 
 ## アプリケーションのProdModule
 
-既定のProdModuleに対してアプリケーションの`ProdModule`を`src/Module/ProdModule.php`に設置してカスタマイズします。特にエラーページと分散キャッシュは重要です。
+既定のProdModuleに対してアプリケーションの`ProdModule`を`src/Module/ProdModule.php`に設置してカスタマイズします。
 
 ```php
 <?php
-namespace MyVendor\Todo\Module;
+
+namespace MyVendor\MyProject\Module;
 
 use BEAR\Package\Context\ProdModule as PackageProdModule;
+use BEAR\Package\Provide\Error\ErrorPageFactoryInterface;
 use BEAR\QueryRepository\CacheVersionModule;
 use BEAR\Resource\Module\OptionsMethodModule;
-use BEAR\Package\AbstractAppModule;
+use Ray\Di\AbstractModule;
 
 class ProdModule extends AbstractModule
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
-        $this->install(new PackageProdModule);       // デフォルトのprod設定
+        $this->install(new PackageProdModule);       // 既定のprod束縛
         $this->override(new OptionsMethodModule);    // OPTIONSメソッドをプロダクションでも有効に
         $this->install(new CacheVersionModule('1')); // リソースキャッシュのバージョン指定
-        
+
         // 独自のエラーページ
         $this->bind(ErrorPageFactoryInterface::class)->to(MyErrorPageFactory::class);
     }
 }
 ```
 
-## キャッシュ
+デプロイ環境に応じてこのモジュールに足すものが、このページの残りです。
 
-キャッシュには、ローカルキャッシュと複数のWebサーバー間で共有する分散キャッシュの2種類があります。どちらのキャッシュもデフォルトは[PhpFileCache](https://www.doctrine-project.org/projects/doctrine-cache/en/1.10/index.html#phpfilecache)です。
+* [分散キャッシュ](#cache) — 2台以上のWebサーバーで必要
+* [キャッシュバージョン](#cache-version) — リソースのスキーマ変更時にキャッシュを破棄
+* [リソース実行ログ](#logging)
+* [エラーログのファイル出力](#error-log)
+* [書き込み先の宣言](#writable-paths) — サーバーレスや読み取り専用コンテナで必要
+
+## キャッシュ {#cache}
+
+キャッシュには、ローカルキャッシュと複数のWebサーバー間で共有する分散キャッシュの2種類があります。
 
 ### ローカルキャッシュ
 
-ローカルキャッシュはデプロイ後に変更されないアノテーションなどのキャッシュに使われ、分散キャッシュはリソース状態の保存に使われます。
+ローカルキャッシュはアノテーションなど、デプロイ後に変更されないもののキャッシュに使われます。[APCu](https://www.php.net/manual/ja/book.apcu.php)が有効ならAPCuに、なければファイルに書かれます。
 
 ### 分散キャッシュ
 
-2つ以上のWebサーバーでサービスを提供するには分散キャッシュの構成が必要です。代表的なキャッシュエンジンである[memcached](https://www.php.net/manual/ja/book.memcached.php)や[Redis](https://redis.io)向けのモジュールが用意されています。
+リソース状態の保存に使われます。2つ以上のWebサーバーでサービスを提供するには分散キャッシュの構成が必要です。代表的なキャッシュエンジンである[memcached](https://www.php.net/manual/ja/book.memcached.php)や[Redis](https://redis.io)向けのモジュールが用意されています。
 
-### Memcached
+#### Memcached
+
 ```php
-<?php
-namespace BEAR\HelloWorld\Module;
-
-use BEAR\QueryRepository\StorageMemcachedModule;
-use BEAR\Resource\Module\ProdLoggerModule;
-use BEAR\Package\Context\ProdModule as PackageProdModule;
-use BEAR\Package\AbstractAppModule;
-use Ray\Di\Scope;
-
-class ProdModule extends AbstractModule
-{
-    protected function configure()
-    {
-        // memcache
-        // {host}:{port}:{weight},...
-        $memcachedServers = 'mem1.domain.com:11211:33,mem2.domain.com:11211:67';
-        $this->install(new StorageMemcachedModule($memcachedServers));
-        
-        // Prodロガーのインストール
-        $this->install(new ProdLoggerModule);
-        
-        // デフォルトのProdModuleのインストール
-        $this->install(new PackageProdModule);
-    }
-}
+// {host}:{port}:{weight},...
+$memcachedServers = 'mem1.domain.com:11211:33,mem2.domain.com:11211:67';
+$this->install(new StorageMemcachedModule($memcachedServers));
 ```
 
-### Redis
+#### Redis
 
 ```php
-// redis
 $redisServer = 'localhost:6379'; // {host}:{port}
 $this->install(new StorageRedisModule($redisServer));
 ```
@@ -113,7 +98,7 @@ $long = 24 * 3600;
 $this->install(new StorageExpiryModule($short, $medium, $long));
 ```
 
-### キャッシュバージョンの指定
+### キャッシュバージョンの指定 {#cache-version}
 
 リソースのスキーマが変わり、互換性が失われる時にはキャッシュバージョンを変更します。特にTTL時間で消えないCQRS運用の場合に重要です。
 
@@ -123,9 +108,13 @@ $this->install(new CacheVersionModule($cacheVersion));
 
 デプロイの度にリソースキャッシュを破棄するためには`$cacheVersion`に時刻や乱数の値を割り当てると変更が不要で便利です。
 
-## ログ
+## ログ {#logging}
 
 `ProdLoggerModule`はプロダクション用のリソース実行ログモジュールです。インストールするとGET以外のリクエストを`Psr\Log\LoggerInterface`にバインドされているロガーでログします。
+
+```php
+$this->install(new ProdLoggerModule);
+```
 
 特定のリソースや特定の状態でログしたい場合は、カスタムのログを[BEAR\Resource\LoggerInterface](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/LoggerInterface.php)にバインドします。
 
@@ -144,7 +133,7 @@ final class MyProdLoggerModule extends AbstractModule
 
 [LoggerInterface](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/LoggerInterface.php)の`__invoke`メソッドでリソースのURIとリソース状態が`ResourceObject`オブジェクトとして渡されるのでその内容で必要な部分をログします。作成には[既存の実装 ProdLogger](https://github.com/bearsunday/BEAR.Resource/blob/1.x/src/ProdLogger.php)を参考にしてください。
 
-### エラーログ
+### エラーログ {#error-log}
 
 捕捉されなかったエラーはレスポンスに`logref` IDを付与し、整形された例外を`Psr\Log\LoggerInterface`にバインドされたロガーへ送ります（独自のロガーをバインドしていなければPHPの`error_log`）。既定では`var/log/{context}`に`logref.{id}.log`ファイルも書かれ、`last.logref.log`が最新のものを指します。`ProdModule`は代わりに`NullLogRefWriter`をバインドするため、プロダクションではファイルを書きません。エラーごとのファイルを残すには、アプリケーションの`ProdModule`で`LogRefWriterInterface`を`FileLogRefWriter`にバインドします。
 
@@ -158,6 +147,7 @@ final class MyProdLoggerModule extends AbstractModule
 * [Deployer](http://deployer.org/)の[BEAR.Sundayレシピ](https://github.com/bearsunday/deploy)を利用することができます。
 
 #### クラウドにデプロイする時には
+
 * コンパイルが成功すると0、依存関係の問題を見つけるとコンパイラはexitコード1を出力します。それを利用してCIにコンパイルを組み込むことを推奨します。
 
 <a id="compilation"></a>
@@ -167,7 +157,7 @@ final class MyProdLoggerModule extends AbstractModule
 
 **原則: できればデプロイ先でコンパイルする**（warmup / health check のタイミング）。パスや環境変数など実環境の実値がそのまま反映されるので、値は正しく焼き込まれます。
 
-**例外: 事前コンパイルが要る環境**（サーバーレス、read-only なアプリルート、`/tmp` などパス固定）。実サービスに触れない場所でコンパイルするため、[書き込み先の宣言](#writable-paths)・AOT スクリプトの再利用・（触れないサービスを通す）`.compile.php` を併用し、**ランタイムで変わる値（接続先・トークン等）は焼き込まずランタイム解決**にします。
+**例外: 事前コンパイルが要る環境**（サーバーレス、read-only なアプリルート、`/tmp` などパス固定）。実サービスに触れない場所でコンパイルするため、[書き込み先の宣言](#writable-paths)・AOT スクリプトの再利用・（触れないサービスを通す）[`.compile.php`](#compile-php)を併用し、**ランタイムで変わる値（接続先・トークン等）は焼き込まずランタイム解決**にします。
 
 ビルドスクリプトはアプリケーションを**名乗るだけ**で、起動はしません（BEAR.Package 1.22以降。スケルトンは`bin/compile.php`）。
 
@@ -196,6 +186,12 @@ exit((new Compiler('MyVendor\MyProject', $context, dirname(__DIR__)))());
 * コンパイルをすれば全てのクラスでインジェクションを行うのでランタイムでDIのエラーが出る可能性が極めて低くなります。
 * `.env`に含まれた内容はPHPファイルに取り込まれるのでコンパイル後に`.env`を消去可能です。
 
+DIスクリプトの出力先は`{appDir}/var/build/{context}/di`です。ビルドディレクトリにはコンパイルが作ったものだけが入り、リクエストが書くものは入りません。だから読み取り専用で配れます。成果物に同梱されていれば実行時はコンパイルせず読むだけです。
+
+`vendor/bin/bear.compile` は BEAR.Package 1.24 で削除されました。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
+
+#### 複数コンテキストのコンパイル {#multiple-contexts}
+
 コンテントネゴシエーションを行う場合など（例：api-app, html-app）1つのアプリケーションで複数コンテキストをコンパイルするときは、スクリプト内のループにします。`autoload.php`と`preload.php`は固定パスに書かれ、次のコンパイルで消えるので、その都度 rename します。
 
 ```php
@@ -222,10 +218,6 @@ exit(0);
 
 context ごとにアーカイブにする場合はループが別で、preloadのrenameもしません → [Phar](phar.html)
 
-DIスクリプトの出力先は`{appDir}/var/build/{context}/di`です。ビルドディレクトリにはコンパイルが作ったものだけが入り、リクエストが書くものは入りません。だから読み取り専用で配れます。成果物に同梱されていれば実行時はコンパイルせず読むだけです。
-
-`vendor/bin/bear.compile` は BEAR.Package 1.24 で削除されました。移行手順は [BEAR.Package#482](https://github.com/bearsunday/BEAR.Package/issues/482) を参照してください。
-
 #### compile step {#compile-steps}
 
 モジュールは compile step（`BEAR\Sunday\Compile\CompileStepInterface`）をバインドでき、コンパイルがそれを実行します。step にはビルドディレクトリの下に自分専用の空のディレクトリが渡されます。名前はバインディングのキーで、書いたものは成果物に同梱されます。
@@ -240,7 +232,76 @@ DIスクリプトの出力先は`{appDir}/var/build/{context}/di`です。ビル
 
 bear/sunday 1.9以降が必要です。背景: [BEAR.Package#501](https://github.com/bearsunday/BEAR.Package/pull/501)
 
-#### 読み取り専用デプロイ（サーバーレス、イミュータブルコンテナ） {#writable-paths}
+#### .compile.php {#compile-php}
+
+実環境ではないと生成ができないクラス（例えば認証が成功しないとインジェクトが完了しないResourceObject）がある場合には、コンパイル時にのみ読み込まれるダミークラス読み込みをルートの`.compile.php`に記述することによってコンパイルをすることができます。**目的は「コンパイル時に構築を通す」ことなので、中身は Null オブジェクト（何もしない実装）が基本**です。これは事前コンパイル（実サービスに触れない）だけでなく、**認証などリクエスト時の状態が要るために、デプロイ先でコンパイルしても構築できない**リソースにも当てはまります。値の偽装（`$_SERVER['X'] = 'fake'` など）は最小限にとどめ、ランタイムで本物が要る値には使わないでください（焼き込まれます）。
+
+**注意**: `.compile.php` はCompiler自身が、コンテナを組む前に読み込みます。削除された `vendor/bin/bear.compile` も読み込んでいました。アプリ側で何かする必要はありません。
+
+例) 例えばコンストラクタで認証が得られない場合に例外を出してしまうAuthProviderがあったとしたら以下のように空のクラスを作っておいて、.compile.phpに読み込ませます。
+
+/tests/Null/AuthProvider.php
+```php
+<?php
+class AuthProvider 
+{  // newをするだけのdummyなので実装は不要
+}
+```
+
+.compile.php
+```php
+<?php
+require __DIR__ . '/tests/Null/AuthProvider.php'; // 常に生成可能なNullオブジェクト
+$_SERVER['YOUR_REQUIRED_ENV'] = 'fake'; // 特定の環境変数がないとエラーになる場合
+```
+
+こうする事で例外を避けてコンパイルを行うことができます。他にもSymfonyのキャッシュコンポーネントはコンストラクタでキャッシュエンジンに接続を行うので、コンパイル時にはこのようにダミーのアダプターを読み込むようにしておくと良いでしょう。
+
+tests/Null/RedisAdapter.php
+```php
+namespace Ray\PsrCacheModule;
+
+use Ray\Di\ProviderInterface;
+use Serializable;
+use Symfony\Component\Cache\Adapter\RedisAdapter as OriginAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+class RedisAdapter extends OriginAdapter implements Serializable
+{
+    use SerializableTrait;
+
+    public function __construct(ProviderInterface $redisProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
+    {
+        // do nothing
+    }
+}
+```
+
+#### autoload.php {#autoloadphp}
+
+`{project_path}/autoload.php` に最適化された autoload ファイルが出力されます。`composer dump-autoload --optimize` の `vendor/autoload.php` より軽く、**preload を使わない構成**でリクエストごとの autoload コストを下げます。
+
+注意：`preload.php` を使う場合は利用クラスの大半が起動時に読み込まれるので、この `autoload.php` はほぼ不要です（composer の `vendor/autoload.php` で十分）。つまり `autoload.php` は **preload を使えない環境向けのフォールバック**という位置づけです。
+
+#### preload.php {#preloadphp}
+
+`{project_path}/preload.php`に最適化されたpreload.phpファイルが出力されます。preloadを有効にするためにはphp.iniで[opcache.preload](https://www.php.net/manual/ja/opcache.configuration.php#ini.opcache.preload)、[opcache.preload_user](https://www.php.net/manual/ja/opcache.configuration.php#ini.opcache.preload-user)を指定する必要があります。
+
+例）
+```ini
+opcache.preload=/path/to/project/preload.php
+opcache.preload_user=www-data
+```
+
+#### module.dot {#module-dot}
+
+コンパイルをすると"dotファイル"が出力されるので[graphviz](https://graphviz.org/)で画像ファイルに変換するか、[GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/)を利用すればオブジェクトグラフを表示することができます。スケルトンの[オブジェクトグラフ](/images/screen/skeleton.svg)もご覧ください。
+
+```bash
+dot -T svg module.dot > module.svg
+```
+
+### 読み取り専用デプロイ（サーバーレス、イミュータブルコンテナ） {#writable-paths}
 
 サーバーレスやイミュータブルコンテナでは書き込めるディレクトリが制限されることがあります。VercelやAWS Lambda、`docker run --read-only`や`readOnlyRootFilesystem: true`で起動したコンテナでは、プロジェクトのディレクトリは読み取り専用で、書き込めるのは`/tmp`など1つのディレクトリだけです。通常のVPSや共有ホストでは不要です。
 
@@ -305,7 +366,7 @@ $this->install(new ReadOnlyAppModule(logDir: '/var/log/myapp'));
 
 BEAR.Package 1.24以降が必要です。背景: [BEAR.Package#491](https://github.com/bearsunday/BEAR.Package/pull/491)
 
-#### Dockerマルチステージビルド {#docker-multi-stage}
+### Dockerマルチステージビルド {#docker-multi-stage}
 
 コンパイルはビルドの仕事です。Dockerの[マルチステージビルド](https://docs.docker.com/build/building/multi-stage/)を使うと、コンパイルをイメージのビルドに固定できます。
 
@@ -324,96 +385,3 @@ COPY --from=build /app /var/www/app
 起動するイメージにはコンパイル済みのDIスクリプトが入っていて、起動時にすることが残っていません。コールドスタートは成果物を読むだけになり（上記の実測で0.38秒→0.018秒）、スケールアウトで増えるインスタンスはすべて同じ成果物から起動するので、どのコンテナも同じ答えを返します。実行ステージを`docker run --read-only`で起動するなら[書き込み先の宣言](#writable-paths)と合わせます。
 
 これは[コンパイル](#compilation-recommended)の「例外: 事前コンパイルが要る環境」にあたります。接続先やトークンなどランタイムで変わる値は焼き込まず、ランタイム解決にします。
-
-### autoload.php
-
-`{project_path}/autoload.php` に最適化された autoload ファイルが出力されます。`composer dump-autoload --optimize` の `vendor/autoload.php` より軽く、**preload を使わない構成**でリクエストごとの autoload コストを下げます。
-
-注意：`preload.php` を使う場合は利用クラスの大半が起動時に読み込まれるので、この `autoload.php` はほぼ不要です（composer の `vendor/autoload.php` で十分）。つまり `autoload.php` は **preload を使えない環境向けのフォールバック**という位置づけです。
-
-### preload.php
-
-`{project_path}/preload.php`に最適化されたpreload.phpファイルが出力されます。preloadを有効にするためにはphp.iniで[opcache.preload](https://www.php.net/manual/ja/opcache.configuration.php#ini.opcache.preload)、[opcache.preload_user](https://www.php.net/manual/ja/opcache.configuration.php#ini.opcache.preload-user)を指定する必要があります。
-
-PHP 7.4でサポートされた機能ですが、`7.4`初期のバージョンでは不安定です。`7.4.4`以上の最新版を使いましょう。
-
-例）
-```ini
-opcache.preload=/path/to/project/preload.php
-opcache.preload_user=www-data
-```
-
-Note: パフォーマンスベンチマークは[benchmark](https://github.com/bearsunday/BEAR.HelloWorldBenchmark/wiki/Intel-Core-i5-3.8-GHz-iMac-(Retina-5K,-27-inch,-2017)---PHP-7.4.4)を参考にしてください。(2020年）
-
-### .compile.php
-
-実環境ではないと生成ができないクラス（例えば認証が成功しないとインジェクトが完了しないResourceObject）がある場合には、コンパイル時にのみ読み込まれるダミークラス読み込みをルートの`.compile.php`に記述することによってコンパイルをすることができます。**目的は「コンパイル時に構築を通す」ことなので、中身は Null オブジェクト（何もしない実装）が基本**です。これは事前コンパイル（実サービスに触れない）だけでなく、**認証などリクエスト時の状態が要るために、デプロイ先でコンパイルしても構築できない**リソースにも当てはまります。値の偽装（`$_SERVER['X'] = 'fake'` など）は最小限にとどめ、ランタイムで本物が要る値には使わないでください（焼き込まれます）。
-
-**注意**: `.compile.php` はCompiler自身が、コンテナを組む前に読み込みます。削除された `vendor/bin/bear.compile` も読み込んでいました。アプリ側で何かする必要はありません。
-
-.compile.php
-
-例) 例えばコンストラクタで認証が得られない場合に例外を出してしまうAuthProviderがあったとしたら以下のように空のクラスを作っておいて、.compile.phpに読み込ませます。
-
-/tests/Null/AuthProvider.php
-```php
-<?php
-class AuthProvider 
-{  // newをするだけのdummyなので実装は不要
-}
-```
-
-.compile.php
-```php
-<?php
-require __DIR__ . '/tests/Null/AuthProvider.php'; // 常に生成可能なNullオブジェクト
-$_SERVER['YOUR_REQUIRED_ENV'] = 'fake'; // 特定の環境変数がないとエラーになる場合
-```
-
-こうする事で例外を避けてコンパイルを行うことができます。他にもSymfonyのキャッシュコンポーネントはコンストラクタでキャッシュエンジンに接続を行うので、コンパイル時にはこのようにダミーのアダプターを読み込むようにしておくと良いでしょう。
-
-tests/Null/RedisAdapter.php
-```php
-namespace Ray\PsrCacheModule;
-
-use Ray\Di\ProviderInterface;
-use Serializable;
-use Symfony\Component\Cache\Adapter\RedisAdapter as OriginAdapter;
-use Symfony\Component\Cache\Marshaller\MarshallerInterface;
-
-class RedisAdapter extends OriginAdapter implements Serializable
-{
-    use SerializableTrait;
-
-    public function __construct(ProviderInterface $redisProvider, string $namespace = '', int $defaultLifetime = 0, ?MarshallerInterface $marshaller = null)
-    {
-        // do nothing
-    }
-}
-```
-
-### module.dot
-
-コンパイルをすると"dotファイル"が出力されるので[graphviz](https://graphviz.org/)で画像ファイルに変換するか、[GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/)を利用すればオブジェクトグラフを表示することができます。スケルトンの[オブジェクトグラフ](/images/screen/skeleton.svg)もご覧ください。
-
-```bash
-dot -T svg module.dot > module.svg
-```
-
-## ブートストラップのパフォーマンスチューニング
-
-[immutable_cache](https://pecl.php.net/package/immutable_cache)は、不変の値を共有メモリにキャッシュするためのPECLパッケージです。APCuをベースにしていますが、PHPのオブジェクトや配列などの不変の値を共有メモリに保存するため、APCuよりも高速です。また、APCuでもimmutable_cacheでも、PECLの[Igbinary](https://www.php.net/manual/ja/book.igbinary.php)をインストールすることでメモリ使用量が減り、さらなる高速化が期待できます。
-
-現在、専用のキャッシュアダプターなどは用意されていません。[ImmutableBootstrap](https://github.com/koriym/BEAR.Hello/commit/507d1ee3ed514686be2d786cdaae1ba8bed63cc4)を参考に、専用のBootstrapを作成し呼び出してください。初期化コストを最小限に抑え、最大のパフォーマンスを得ることができます。
-
-### php.ini
-```ini
-// エクステンション
-extension="apcu.so"
-extension="immutable_cache.so"
-extension="igbinary.so"
-
-// シリアライザーの指定
-apc.serializer=igbinary
-immutable_cache.serializer=igbinary
-```

--- a/manuals/1.0/ja/production.md
+++ b/manuals/1.0/ja/production.md
@@ -55,6 +55,7 @@ class ProdModule extends AbstractModule
 * [キャッシュバージョン](#cache-version) — リソースのスキーマ変更時にキャッシュを破棄
 * [リソース実行ログ](#logging)
 * [エラーログのファイル出力](#error-log)
+* [エラーログサーバー](#error-log-server) — 4xxのノイズを送らないロガー束縛
 * [書き込み先の宣言](#writable-paths) — サーバーレスや読み取り専用コンテナで必要
 
 ## キャッシュ {#cache}
@@ -135,7 +136,37 @@ final class MyProdLoggerModule extends AbstractModule
 
 ### エラーログ {#error-log}
 
-捕捉されなかったエラーはレスポンスに`logref` IDを付与し、整形された例外を`Psr\Log\LoggerInterface`にバインドされたロガーへ送ります（独自のロガーをバインドしていなければPHPの`error_log`）。既定では`var/log/{context}`に`logref.{id}.log`ファイルも書かれ、`last.logref.log`が最新のものを指します。`ProdModule`は代わりに`NullLogRefWriter`をバインドするため、プロダクションではファイルを書きません。エラーごとのファイルを残すには、アプリケーションの`ProdModule`で`LogRefWriterInterface`を`FileLogRefWriter`にバインドします。
+捕捉されなかった例外は`Psr\Log\LoggerInterface`にバインドされたロガーへ送られます（独自のロガーをバインドしていなければPHPの`error_log`）。ログレベルはエラーページと同じ基準で決まります。クライアント起因（`BadRequestException`系、4xx）はdebug、サーバー障害（5xx）はerrorです。
+
+サーバー障害はレスポンスに`logref` IDを付与し、同じIDがログにも記録されます。既定では`var/log/{context}`に`logref.{id}.log`ファイルも書かれ、`last.logref.log`が最新のものを指します。`ProdModule`は代わりに`NullLogRefWriter`をバインドするため、プロダクションではファイルを書きません。エラーごとのファイルを残すには`LogRefWriterInterface`を`FileLogRefWriter`にバインドします。ファイルはリクエストを処理したサーバーに書かれます。
+
+### エラーログサーバー {#error-log-server}
+
+Sentryのようなエラーログサーバーを使う場合は、errorレベル以上だけを送るハンドラを持つロガーを`LoggerInterface`に束縛します。4xxはdebugでログされるため、404や405のスキャンノイズは届きません。
+
+```php
+$this->bind(LoggerInterface::class)->toProvider(AppLoggerProvider::class)->in(Scope::SINGLETON);
+```
+
+プロバイダーでMonologを組み、エラーログサーバーのハンドラだけ閾値を`Level::Error`にします。接続先のDSNはランタイムで解決します（[コンパイル](#compilation-recommended)で焼き込まない）。
+
+### ドメイン例外 {#domain-exceptions}
+
+アプリケーション独自の例外もこの基準で分類されます。クライアント起因の例外は`BadRequestException`を継承し、HTTPコードをコンストラクタで指定します。それだけで、エラーページのステータスコード・ログレベル・エラーログサーバーに送られるかどうかが決まります。
+
+```php
+use BEAR\Resource\Exception\BadRequestException;
+
+final class CartExpired extends BadRequestException
+{
+    public function __construct(string $cartId)
+    {
+        parent::__construct($cartId, 410);
+    }
+}
+```
+
+410 Goneのページが返り、ログはdebugです。`BadRequestException`を継承しない例外はサーバー障害として扱われます（`RuntimeException`系は503、その他は500。ログはerror）。
 
 ## デプロイ
 


### PR DESCRIPTION
Documents the BEAR.Package 1.22–1.24 deployment releases and reworks the production manual around them (ja/en).

- New Phar page; compile docs follow bin/compile.php, compile steps, and the bear.compile removal
- Read-only deployments: ReadOnlyAppModule and declared write locations
- Qiq 2.1 / Twig 2.8 prod modules
- Production page restructured: read-only deployment and Docker multi-stage promoted, compile artifacts folded under compilation, a per-environment customization index added, broken example imports fixed, stale PhpFileCache description replaced, immutable_cache section dropped