### PR TITLE
Clarify the One binary section: heading, opening line, micro caveat

### DIFF
--- a/manuals/1.0/en/phar.md
+++ b/manuals/1.0/en/phar.md
@@ -122,7 +122,7 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 `autoload.php` is not included in the archive. With preload, [autoload.php is no longer needed](production.html#autoloadphp). The `preload.php` the compile wrote cannot be used from beside the archive. Its requires are written relative to its own directory, and there is no `vendor/` outside the archive, so startup fails with `Failed opening required '…/vendor/autoload.php'`. Also, `preload.php` is overwritten at `{appDir}/preload.php` on every compile, so run `phar()` for the context you compiled last. If another context's `preload.php` remains, `PharPreloadForAnotherBuildException` is thrown.
 
-## A binary with PHP built in
+## A binary with PHP built in {#one-binary}
 
 [static-php-cli](https://static-php.dev) builds `php` and `php-fpm`. They're the same binaries as a normal install — the only difference is no shared-library dependencies. No PHP install on the host, no matching the distribution's PHP version. Include the `phar` extension and whatever else the application needs in the build.
 
@@ -139,7 +139,17 @@ Running is the same. Use this binary instead of the host's `php`.
 
 For php-fpm, start `./buildroot/bin/php-fpm` with the `php-fpm.conf` the host's php-fpm uses, passed with `-y`. The entry point placement and the opcache and `opcache.preload` settings are the same as with the host's PHP.
 
-Not `--build-micro`: it builds the micro SAPI binary, and `micro:combine` fuses it with the code into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
+### One executable (CLI) {#one-executable}
+
+For a command-line application, the archive and PHP can be one file. `--build-micro` builds the micro SAPI as `micro.sfx`, a PHP that runs whatever is appended to it. Append the archive.
+
+```bash
+cat micro.sfx app.phar > myapp
+chmod +x myapp
+./myapp get '/index?name=BEAR'
+```
+
+The result is one executable that carries PHP, its extensions, the application and its compiled DI scripts. It can be renamed, copied to another machine of the same platform, and started from any directory, and it writes only where [ReadOnlyAppModule](#readonlyappmodule) says. The micro SAPI runs one script and exits; it has no FPM counterpart for serving requests, so the web entry point stays with php-fpm and the archive beside it. This is for commands and [BEAR.Cli](cli.html) tools. A prebuilt `micro.sfx` for each PHP version and platform is at [dl.static-php.dev](https://dl.static-php.dev/static-php-cli/common/).
 
 ## Copying to another location
 

--- a/manuals/1.0/en/phar.md
+++ b/manuals/1.0/en/phar.md
@@ -124,7 +124,7 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 ## A binary with PHP built in
 
-[static-php-cli](https://static-php.dev) builds the `php` and `php-fpm` interpreter itself, statically linked with no shared-library dependencies. Nothing else changes: no PHP install on the host, no matching the distribution's PHP version. Include the `phar` extension and whatever else the application needs in the build.
+[static-php-cli](https://static-php.dev) builds `php` and `php-fpm`. They're the same binaries as a normal install — the only difference is no shared-library dependencies. No PHP install on the host, no matching the distribution's PHP version. Include the `phar` extension and whatever else the application needs in the build.
 
 ```bash
 ./spc download --for-extensions=phar,opcache -P

--- a/manuals/1.0/en/phar.md
+++ b/manuals/1.0/en/phar.md
@@ -139,7 +139,7 @@ Running is the same. Use this binary instead of the host's `php`.
 
 For php-fpm, start `./buildroot/bin/php-fpm` with the `php-fpm.conf` the host's php-fpm uses, passed with `-y`. The entry point placement and the opcache and `opcache.preload` settings are the same as with the host's PHP.
 
-`--build-micro` and `micro:combine` fuse the binary and the archive into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
+`--build-micro` builds the micro SAPI binary; `micro:combine` fuses it with the code into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
 
 ## Copying to another location
 

--- a/manuals/1.0/en/phar.md
+++ b/manuals/1.0/en/phar.md
@@ -139,7 +139,7 @@ Running is the same. Use this binary instead of the host's `php`.
 
 For php-fpm, start `./buildroot/bin/php-fpm` with the `php-fpm.conf` the host's php-fpm uses, passed with `-y`. The entry point placement and the opcache and `opcache.preload` settings are the same as with the host's PHP.
 
-`--build-micro` builds the micro SAPI binary; `micro:combine` fuses it with the code into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
+Not `--build-micro`: it builds the micro SAPI binary, and `micro:combine` fuses it with the code into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
 
 ## Copying to another location
 

--- a/manuals/1.0/en/phar.md
+++ b/manuals/1.0/en/phar.md
@@ -122,9 +122,9 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 `autoload.php` is not included in the archive. With preload, [autoload.php is no longer needed](production.html#autoloadphp). The `preload.php` the compile wrote cannot be used from beside the archive. Its requires are written relative to its own directory, and there is no `vendor/` outside the archive, so startup fails with `Failed opening required '…/vendor/autoload.php'`. Also, `preload.php` is overwritten at `{appDir}/preload.php` on every compile, so run `phar()` for the context you compiled last. If another context's `preload.php` remains, `PharPreloadForAnotherBuildException` is thrown.
 
-## One binary
+## A binary with PHP built in
 
-[static-php-cli](https://static-php.dev) builds a single PHP binary with no shared-library dependencies. Placing the `php` and `php-fpm` binaries is enough to run. There is no need to install PHP on the host or to match the distribution's PHP version. Include the `phar` extension and the extensions the application uses in the build.
+[static-php-cli](https://static-php.dev) builds the `php` and `php-fpm` interpreter itself, statically linked with no shared-library dependencies. Nothing else changes: no PHP install on the host, no matching the distribution's PHP version. Include the `phar` extension and whatever else the application needs in the build.
 
 ```bash
 ./spc download --for-extensions=phar,opcache -P
@@ -138,6 +138,8 @@ Running is the same. Use this binary instead of the host's `php`.
 ```
 
 For php-fpm, start `./buildroot/bin/php-fpm` with the `php-fpm.conf` the host's php-fpm uses, passed with `-y`. The entry point placement and the opcache and `opcache.preload` settings are the same as with the host's PHP.
+
+`--build-micro` and `micro:combine` fuse the binary and the archive into a single self-extracting file. The micro SAPI runs one script and exits — it has no FPM counterpart for serving requests.
 
 ## Copying to another location
 

--- a/manuals/1.0/ja/phar.md
+++ b/manuals/1.0/ja/phar.md
@@ -139,7 +139,7 @@ static-php-cliは`php`と`php-fpm`を作ります。ふつうにインストー�
 
 php-fpmを使う場合は、ホストのphp-fpmで使っている`php-fpm.conf`を`-y`で渡して`./buildroot/bin/php-fpm`を起動します。エントリポイントの置き方も、opcacheと`opcache.preload`の設定も、ホストのPHPと同じです。
 
-`--build-micro`と`micro:combine`は、バイナリとアーカイブを1つの自己展開ファイルに融合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
+`--build-micro`はmicro SAPIのバイナリをビルドし、`micro:combine`でコードと1つの自己展開ファイルに結合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
 
 ## 別の場所へのコピー
 

--- a/manuals/1.0/ja/phar.md
+++ b/manuals/1.0/ja/phar.md
@@ -122,7 +122,7 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 `autoload.php`はアーカイブに入りません。preloadを使う場合、[autoload.phpは不要になる](production.html#autoloadphp)からです。コンパイルが書いた`preload.php`をアーカイブの隣に置いて使うことはできません。`preload.php`のrequireは自身のディレクトリからの相対パスで書かれていて、アーカイブの外には`vendor/`がないため、起動時に`Failed opening required '…/vendor/autoload.php'`で失敗します。また`preload.php`はコンパイルごとに`{appDir}/preload.php`に上書きされるので、`phar()`は最後にコンパイルした context に対して実行します。別の context の`preload.php`が残っていると`PharPreloadForAnotherBuildException`になります。
 
-## PHPを含んだワンバイナリ
+## PHPを含んだワンバイナリ {#one-binary}
 
 static-php-cliは`php`と`php-fpm`を作ります。ふつうにインストールするのと同じ実行ファイルで、違うのは共有ライブラリに依存しないことだけです。ホストにPHPをインストールする必要も、ディストリビューションのPHPバージョンに合わせる必要もありません。ビルド時には`phar`拡張と、アプリケーションが使う拡張を含めます。
 
@@ -139,7 +139,17 @@ static-php-cliは`php`と`php-fpm`を作ります。ふつうにインストー�
 
 php-fpmを使う場合は、ホストのphp-fpmで使っている`php-fpm.conf`を`-y`で渡して`./buildroot/bin/php-fpm`を起動します。エントリポイントの置き方も、opcacheと`opcache.preload`の設定も、ホストのPHPと同じです。
 
-ここで使うのは`--build-micro`ではありません。これはmicro SAPIのバイナリをビルドするもので、`micro:combine`でコードと1つの自己展開ファイルに結合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
+### 1つの実行ファイル（CLI） {#one-executable}
+
+コマンドラインのアプリケーションなら、アーカイブとPHPを1ファイルにできます。`--build-micro`はmicro SAPIを`micro.sfx`としてビルドします。後ろに付け足されたものを実行するPHPです。アーカイブを付け足します。
+
+```bash
+cat micro.sfx app.phar > myapp
+chmod +x myapp
+./myapp get '/index?name=BEAR'
+```
+
+できるのは、PHPとその拡張、アプリケーションとコンパイル済みDIスクリプトを持った1つの実行ファイルです。名前を変えても、同じプラットフォームの別のマシンにコピーしても、どのディレクトリから起動しても動き、書き込むのは[ReadOnlyAppModule](#readonlyappmodule)が決めた場所だけです。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。Webのエントリポイントはphp-fpmと、その隣のアーカイブのままです。これはコマンドや[BEAR.Cli](cli.html)のツール向けです。PHPバージョンとプラットフォームごとのビルド済み`micro.sfx`は[dl.static-php.dev](https://dl.static-php.dev/static-php-cli/common/)にあります。
 
 ## 別の場所へのコピー
 

--- a/manuals/1.0/ja/phar.md
+++ b/manuals/1.0/ja/phar.md
@@ -139,7 +139,7 @@ static-php-cliは`php`と`php-fpm`を作ります。ふつうにインストー�
 
 php-fpmを使う場合は、ホストのphp-fpmで使っている`php-fpm.conf`を`-y`で渡して`./buildroot/bin/php-fpm`を起動します。エントリポイントの置き方も、opcacheと`opcache.preload`の設定も、ホストのPHPと同じです。
 
-`--build-micro`はmicro SAPIのバイナリをビルドし、`micro:combine`でコードと1つの自己展開ファイルに結合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
+ここで使うのは`--build-micro`ではありません。これはmicro SAPIのバイナリをビルドするもので、`micro:combine`でコードと1つの自己展開ファイルに結合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
 
 ## 別の場所へのコピー
 

--- a/manuals/1.0/ja/phar.md
+++ b/manuals/1.0/ja/phar.md
@@ -122,9 +122,9 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 `autoload.php`はアーカイブに入りません。preloadを使う場合、[autoload.phpは不要になる](production.html#autoloadphp)からです。コンパイルが書いた`preload.php`をアーカイブの隣に置いて使うことはできません。`preload.php`のrequireは自身のディレクトリからの相対パスで書かれていて、アーカイブの外には`vendor/`がないため、起動時に`Failed opening required '…/vendor/autoload.php'`で失敗します。また`preload.php`はコンパイルごとに`{appDir}/preload.php`に上書きされるので、`phar()`は最後にコンパイルした context に対して実行します。別の context の`preload.php`が残っていると`PharPreloadForAnotherBuildException`になります。
 
-## ワンバイナリ
+## PHPを含んだワンバイナリ
 
-[static-php-cli](https://static-php.dev)を使うと、共有ライブラリに依存しない単一のPHPバイナリを作れます。`php`と`php-fpm`のバイナリを置くだけで動き、ホストにPHPをインストールする必要も、ディストリビューションのPHPバージョンに合わせる必要もありません。ビルド時には`phar`拡張と、アプリケーションが使う拡張を含めます。
+[static-php-cli](https://static-php.dev)は、共有ライブラリに依存しない`php`と`php-fpm`のインタプリタ自体を作ります。ほかは何も変わりません。ホストにPHPをインストールする必要も、ディストリビューションのPHPバージョンに合わせる必要もありません。ビルド時には`phar`拡張と、アプリケーションが使う拡張を含めます。
 
 ```bash
 ./spc download --for-extensions=phar,opcache -P
@@ -138,6 +138,8 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 ```
 
 php-fpmを使う場合は、ホストのphp-fpmで使っている`php-fpm.conf`を`-y`で渡して`./buildroot/bin/php-fpm`を起動します。エントリポイントの置き方も、opcacheと`opcache.preload`の設定も、ホストのPHPと同じです。
+
+`--build-micro`と`micro:combine`は、バイナリとアーカイブを1つの自己展開ファイルに融合します。micro SAPIは1つのスクリプトを実行して終了するだけで、リクエストを処理するFPM相当のものはありません。
 
 ## 別の場所へのコピー
 

--- a/manuals/1.0/ja/phar.md
+++ b/manuals/1.0/ja/phar.md
@@ -124,7 +124,7 @@ opcache.preload=phar:///path/to/app.phar/preload.php
 
 ## PHPを含んだワンバイナリ
 
-[static-php-cli](https://static-php.dev)は、共有ライブラリに依存しない`php`と`php-fpm`のインタプリタ自体を作ります。ほかは何も変わりません。ホストにPHPをインストールする必要も、ディストリビューションのPHPバージョンに合わせる必要もありません。ビルド時には`phar`拡張と、アプリケーションが使う拡張を含めます。
+static-php-cliは`php`と`php-fpm`を作ります。ふつうにインストールするのと同じ実行ファイルで、違うのは共有ライブラリに依存しないことだけです。ホストにPHPをインストールする必要も、ディストリビューションのPHPバージョンに合わせる必要もありません。ビルド時には`phar`拡張と、アプリケーションが使う拡張を含めます。
 
 ```bash
 ./spc download --for-extensions=phar,opcache -P


### PR DESCRIPTION
Follow-up to #398, addressing feedback after merge:

- Heading: `One binary` → `A binary with PHP built in` (ja: `ワンバイナリ` → `PHPを含んだワンバイナリ`) — the old heading didn't say PHP is what's bundled
- Opening line: dropped 'the interpreter itself' phrasing (confusing — read as php/php-fpm having some separate 'real' interpreter behind them) for a plain statement of what static-php-cli builds and the one difference from a normal install
- Added: `--build-micro`/`micro:combine` fuse the binary and the archive into one self-extracting file for a different purpose (a CLI tool with nothing installed); the micro SAPI runs one script and exits, no FPM counterpart. Without this, a reader could reach for micro:combine expecting a drop-in alternative for serving requests.

Verified: `bundle exec jekyll build` renders both sections; frontmatter validator passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * PHPを組み込んだバイナリの説明を更新しました。
  * `--build-micro`および`micro:combine`を使った、CLI向け単一実行ファイルの作成手順と実行例を追加しました。
  * 単一実行ファイルの構成と実行上の制約を明記しました。
  * micro SAPIは単一スクリプトの実行に対応し、FPMによるリクエスト処理には対応しないことを説明しました。
  * Web実行では、従来どおりphp-fpmとアーカイブを使用することを追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->