### PR TITLE
Make the async manual the canonical BEAR.Async reference

### DIFF
--- a/manuals/1.0/en/async.md
+++ b/manuals/1.0/en/async.md
@@ -40,7 +40,7 @@ Choose a runtime that matches your server setup.
 | PHP-FPM / Apache (with embedded resources) | `bin/async.php` | the library `bootstrap.php` overlays the parallel runtime on `AppModule` |
 | Swoole HTTP Server | `bin/swoole.php` | install `AsyncSwooleModule` in `AppModule` |
 
-| | ext-parallel | ext-swoole |
+| | ext-parallel | ext-swoole / ext-openswoole |
 |---|---|---|
 | Concurrency | Thread pool (CPU cores) | Coroutines (thousands) |
 | Memory | Separate per worker | Shared (process-level) |
@@ -124,7 +124,7 @@ Install `AsyncSwooleModule` before `PackageModule`. Ray.Di keeps the first bindi
 
 Run the Swoole server on the compiled injector. The reflective `Injector` shares its resolution state across the whole process; when a coroutine suspends inside a provider (waiting for a pooled connection, say), another coroutine enters that state and fails with a `CircularDependency` whose chain is not circular. Boot through `BEAR\Package\Injector` so production contexts get Ray.Compiler's `CompiledInjector`, and call its `warmup()` before the server accepts requests so every singleton is built while there is still a single coroutine. [`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php) shows the sequence; see [Ray.Di: Coroutine servers](https://ray-di.github.io/manuals/1.0/en/performance_boost.html) for the contract.
 
-In Swoole, coroutines share memory, so a connection pool via `PdoPoolEnvModule` is required. In read-heavy setups that make heavy use of embedded resources, the pool size should account not only for the number of incoming HTTP requests but also for the number of embeds executed concurrently within one request. To avoid queueing, use `PDO_POOL_SIZE >= embed_count * request_concurrency` as a starting point; intentionally use a smaller pool when you want to cap concurrent connections to the database.
+In Swoole, coroutines share memory, so a connection pool via `PdoPoolEnvModule` is required. In read-heavy setups that make heavy use of embedded resources, the pool size should account not only for the number of incoming HTTP requests but also for the number of embeds executed concurrently within one request. Each coroutine holds one connection until it ends, and the parent request keeps its own while its embeds run, so start from `PDO_POOL_SIZE >= (1 + embed_count) * request_concurrency`; intentionally use a smaller pool when you want to cap concurrent connections to the database.
 
 `PdoPoolModule` / `RedisPoolModule` and their env-driven counterparts take a `borrowTimeout` (default 5.0 s). Waiting on an exhausted pool fails with `PoolTimeoutException` instead of blocking forever. Every checkout is pinged first (`SELECT 1` for PDO, `PING` for Redis); a dead connection is discarded and retried once, and if the retry is also dead `StalePooledConnectionException` is thrown with the driver error as the previous exception. Redis connections are cached per coroutine the same way PDO connections are, so repeated injections within one coroutine reuse one checkout.
 
@@ -198,7 +198,7 @@ Each runtime requires the corresponding PHP extension.
 | Runtime | Requires | Application-side change |
 |---|---|---|
 | ext-parallel | ZTS PHP + ext-parallel | add `bin/async.php` |
-| ext-swoole | ext-swoole | install `AsyncSwooleModule`, use `bin/swoole.php` |
+| ext-swoole | ext-swoole or ext-openswoole | install `AsyncSwooleModule`, use `bin/swoole.php` |
 
 ## SQL resources with BDR + `#[Embed]`
 

--- a/manuals/1.0/en/async.md
+++ b/manuals/1.0/en/async.md
@@ -40,6 +40,14 @@ Choose a runtime that matches your server setup.
 | PHP-FPM / Apache (with embedded resources) | `bin/async.php` | the library `bootstrap.php` overlays the parallel runtime on `AppModule` |
 | Swoole HTTP Server | `bin/swoole.php` | install `AsyncSwooleModule` in `AppModule` |
 
+| | ext-parallel | ext-swoole |
+|---|---|---|
+| Concurrency | Thread pool (CPU cores) | Coroutines (thousands) |
+| Memory | Separate per worker | Shared (process-level) |
+| PDO handling | Isolated per thread | Connection pool required |
+| Server | PHP-FPM / Apache | Swoole HTTP Server |
+| Setup | Add `bin/async.php` | Add `bin/swoole.php` |
+
 ### Parallel execution (ext-parallel)
 
 A runtime for typical web applications running on PHP-FPM / Apache. It executes `#[Embed]` in parallel using an ext-parallel thread pool.
@@ -80,11 +88,15 @@ To change the worker pool size (defaults to the number of CPU cores), pass it ex
 exit((require $bootstrap)($context, 'MyVendor\MyApp', dirname(__DIR__), $GLOBALS, $_SERVER, 8));
 ```
 
+Do not install the parallel runtime in `AppModule` directly. The bootstrap is the only supported install path, so the same `AppModule` runs unchanged under `bin/app.php` (sequential) and `bin/async.php` (parallel).
+
+Under classic PHP-FPM / Apache the `parallel\Runtime` pool lives in process state, so a request that needs it rebuilds the pool: the thread spawn, autoload, and DI container cost is paid per request. `ParallelAsync` warms one worker synchronously before dispatching, so the container is built once rather than once per thread, but steady-state low latency needs a resident process that keeps the pool warm across requests. See [`demo/bin/parallel-server.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/parallel-server.php) and the [benchmark results](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md).
+
 #### ext-parallel constraints
 
 Workers run on separate threads, each with an independent Zend memory space. Embedded resources executed in parallel should be read-only (idempotent GET) resources with no ordering dependency. Because each worker holds its own DI container, request-local mutable state and "same instance" assumptions do not carry across thread boundaries.
 
-Arguments and return values that cross the thread boundary must be copyable: scalar values, `null`, and nested arrays of those. Passing objects, closures, or resources fails immediately. Keep any interceptors applied to embedded resources executed in parallel idempotent, and do not mutate request-local shared state.
+Arguments and return values that cross the thread boundary must be copyable: scalar values, `null`, and nested arrays of those. Objects, closures, and resources fail fast with `NonCopyablePayloadException`. Keep any interceptors applied to embedded resources executed in parallel idempotent, and do not mutate request-local shared state.
 
 ### Swoole execution (ext-swoole)
 
@@ -95,18 +107,28 @@ Because ext-parallel runs in workers (separate threads), it is selected via a se
 ```php
 use BEAR\Async\Module\AsyncSwooleModule;
 use BEAR\Async\Module\PdoPoolEnvModule;
+use BEAR\Package\PackageModule;
 
 class AppModule extends AbstractModule
 {
     protected function configure(): void
     {
         $this->install(new AsyncSwooleModule());
+        $this->install(new PackageModule());
         $this->install(new PdoPoolEnvModule('PDO_DSN', 'PDO_USER', 'PDO_PASSWORD'));
     }
 }
 ```
 
+Install `AsyncSwooleModule` before `PackageModule`. Ray.Di keeps the first binding it sees, so in the reverse order the framework's sequential `LinkCrawler` and `EmbedInterceptor` win and `#[Embed]` silently runs sequentially.
+
+Run the Swoole server on the compiled injector. The reflective `Injector` shares its resolution state across the whole process; when a coroutine suspends inside a provider (waiting for a pooled connection, say), another coroutine enters that state and fails with a `CircularDependency` whose chain is not circular. Boot through `BEAR\Package\Injector` so production contexts get Ray.Compiler's `CompiledInjector`, and call its `warmup()` before the server accepts requests so every singleton is built while there is still a single coroutine. [`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php) shows the sequence; see [Ray.Di: Coroutine servers](https://ray-di.github.io/manuals/1.0/en/performance_boost.html) for the contract.
+
 In Swoole, coroutines share memory, so a connection pool via `PdoPoolEnvModule` is required. In read-heavy setups that make heavy use of embedded resources, the pool size should account not only for the number of incoming HTTP requests but also for the number of embeds executed concurrently within one request. To avoid queueing, use `PDO_POOL_SIZE >= embed_count * request_concurrency` as a starting point; intentionally use a smaller pool when you want to cap concurrent connections to the database.
+
+`PdoPoolModule` / `RedisPoolModule` and their env-driven counterparts take a `borrowTimeout` (default 5.0 s). Waiting on an exhausted pool fails with `PoolTimeoutException` instead of blocking forever. Every checkout is pinged first (`SELECT 1` for PDO, `PING` for Redis); a dead connection is discarded and retried once, and if the retry is also dead `StalePooledConnectionException` is thrown with the driver error as the previous exception. Redis connections are cached per coroutine the same way PDO connections are, so repeated injections within one coroutine reuse one checkout.
+
+Never inject `ExtendedPdoInterface`, `PDO`, or `Redis` into a singleton. The provider hands out a connection borrowed for one coroutine; a singleton would hold that connection for the life of the process, defeating the pool and mixing coroutines. Keep DB-using dependencies prototype-scoped (the default), or inject `ProviderInterface<ExtendedPdoInterface>` and call `get()` per use.
 
 > **Technical note (pool connection acquisition):** Connection acquisition from the pool is managed per coroutine. Even when both `PDO` and `ExtendedPdo` are injected within the same coroutine, they share a single connection and that connection is returned to the pool exactly once via `Coroutine::defer()` when the coroutine ends. This prevents a single piece of work from unintentionally holding two connections. Furthermore, requests embedded via `#[Embed]` are lazily evaluated, so the pool is not touched at the point the embed is declared with `#[Embed]`; connection acquisition is deferred until each request is actually executed.
 >
@@ -144,6 +166,27 @@ The "function coloring" problem often raised in async programming — a function
 
 This is not specific to BEAR.Async; it is a property of BEAR.Sunday as a whole. Where MVC frameworks write *how to execute* procedurally, BEAR.Sunday expresses *relationships between resources* declaratively. Because the declaration is independent of the execution strategy, swapping strategies has no effect on the code.
 
+## How it works
+
+BEAR.Async replaces two bear/resource bindings:
+
+1. `LinkCrawlerInterface` → `AsyncLinkCrawler`: crawls `#[Link(crawl:)]` graphs level by level. Requests at each level are batched, deduplicated by URI+query hash, and executed together; results are distributed to every requester.
+2. `EmbedInterceptorInterface` → `AsyncEmbedInterceptor`: wraps each `#[Embed]` in an `AsyncRequest` over a `DeferredRequest` and registers it with `PendingRequests`, which dispatches every pending embed as one batch the first time any of them is rendered.
+
+Both hand the batch to the configured `AsyncInterface` adapter: `ParallelAsync`, `SwooleAsync`, or `SyncAsync` (the default when no runtime module is installed).
+
+```text
+Level 1: Users → all user requests execute in parallel
+Level 2: Posts for each user → all post requests execute in parallel
+Level 3: Comments for each post → all comment requests execute in parallel
+```
+
+### Failure semantics
+
+One failing embed or crawl task does not kill the Swoole worker or abort its siblings: every task runs to completion, then the first exception is rethrown to the caller, producing a 500 for that request alone. `ParallelAsync` follows the same rule: every dispatched `Future` is joined before the first `Throwable` is rethrown.
+
+There is no silent fallback. If the required extension is not loaded, the owning module throws `ExtensionNotLoadedException` from `configure()` rather than degrading to `SyncAsync`.
+
 ## Demo and benchmarks
 
 The BEAR.Async repository includes a Docker-based demo and benchmark scripts that compare Sync, ext-parallel, and Swoole behavior. See the [demo guide](https://github.com/bearsunday/BEAR.Async/tree/1.x/demo) and [benchmark results](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md) for details.
@@ -159,7 +202,7 @@ Each runtime requires the corresponding PHP extension.
 
 ## SQL resources with BDR + `#[Embed]`
 
-To run multiple SQL queries for one page, split each query into its own `ResourceObject` and let `#[Embed]` parallelize them via AsyncLinker. The call site just composes resources — the runtime decides how to execute the embeds in parallel.
+To run multiple SQL queries for one page, split each query into its own `ResourceObject` and let `#[Embed]` parallelize them. The call site just composes resources — the runtime decides how to execute the embeds in parallel.
 
 Combined with Ray.MediaQuery's [BDR pattern](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md) (`#[DbQuery]` interface + factory + immutable domain object), SQL stays in `var/sql/*.sql`, the call site reads as plain objects, and the resource graph itself is what gets parallelized.
 
@@ -207,7 +250,7 @@ class User extends ResourceObject
     }
 }
 
-// Aggregate — Embeds parallelize automatically under AsyncLinker
+// Aggregate — the embeds run in parallel under BEAR.Async
 class UserDashboard extends ResourceObject
 {
     #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
@@ -222,7 +265,7 @@ class UserDashboard extends ResourceObject
 
 - SQL stays in `var/sql/*.sql` (Ray.MediaQuery convention)
 - Domain objects are immutable snapshots; no `$results['user'][0] ?? null` plumbing at the call site
-- AsyncLinker runs the three embeds in parallel via ext-parallel (PHP-FPM / Apache) or Swoole coroutines
+- BEAR.Async runs the three embeds in parallel via ext-parallel (PHP-FPM / Apache) or Swoole coroutines
 - Without ext-parallel and without Swoole the same code runs synchronously per request, which is fine for PHP-FPM (each request is its own process)
 - For Swoole, install `PdoPoolEnvModule` so each coroutine borrows a pooled PDO connection
 

--- a/manuals/1.0/en/async.md
+++ b/manuals/1.0/en/async.md
@@ -38,7 +38,7 @@ Choose a runtime that matches your server setup.
 | Use case | Entrypoint | Runtime setup |
 |---|---|---|
 | PHP-FPM / Apache (with embedded resources) | `bin/async.php` | the library `bootstrap.php` overlays the parallel runtime on `AppModule` |
-| Swoole HTTP Server | `bin/swoole.php` | install `AsyncSwooleModule` in `AppModule` |
+| Swoole HTTP Server | `bin/swoole.php` | a `swoole` context module installs `AsyncSwooleModule`; `AppModule` is unchanged |
 
 | | ext-parallel | ext-swoole / ext-openswoole |
 |---|---|---|
@@ -102,25 +102,26 @@ Arguments and return values that cross the thread boundary must be copyable: sca
 
 A runtime for applications already running on a Swoole HTTP server and aiming for high concurrency.
 
-Because ext-parallel runs in workers (separate threads), it is selected via a separate entrypoint. ext-swoole, on the other hand, runs inside the same server process, so it is installed as an application module.
+ext-parallel runs in worker threads, so it is selected by a separate entrypoint. ext-swoole runs inside the server process, so it is selected by the context string: add a `swoole` context module and boot with a context such as `prod-swoole-hal-api-app`. `AppModule` stays as it is, and `bin/app.php` with `hal-api-app` still runs sequentially for development.
 
 ```php
+namespace MyVendor\MyApp\Module;
+
 use BEAR\Async\Module\AsyncSwooleModule;
 use BEAR\Async\Module\PdoPoolEnvModule;
-use BEAR\Package\PackageModule;
+use Ray\Di\AbstractModule;
 
-class AppModule extends AbstractModule
+final class SwooleModule extends AbstractModule
 {
     protected function configure(): void
     {
         $this->install(new AsyncSwooleModule());
-        $this->install(new PackageModule());
         $this->install(new PdoPoolEnvModule('PDO_DSN', 'PDO_USER', 'PDO_PASSWORD'));
     }
 }
 ```
 
-Install `AsyncSwooleModule` before `PackageModule`. Ray.Di keeps the first binding it sees, so in the reverse order the framework's sequential `LinkCrawler` and `EmbedInterceptor` win and `#[Embed]` silently runs sequentially.
+A context module wraps `AppModule`, so its bindings take precedence over the framework's sequential `LinkCrawler` and `EmbedInterceptor`. Do not install `AsyncSwooleModule` inside `AppModule` instead: Ray.Di keeps the first binding, and installed after `PackageModule` the async bindings are silently dropped.
 
 Run the Swoole server on the compiled injector. The reflective `Injector` shares its resolution state across the whole process; when a coroutine suspends inside a provider (waiting for a pooled connection, say), another coroutine enters that state and fails with a `CircularDependency` whose chain is not circular. Boot through `BEAR\Package\Injector` so production contexts get Ray.Compiler's `CompiledInjector`, and call its `warmup()` before the server accepts requests so every singleton is built while there is still a single coroutine. [`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php) shows the sequence; see [Ray.Di: Coroutine servers](https://ray-di.github.io/manuals/1.0/en/performance_boost.html) for the contract.
 
@@ -198,7 +199,7 @@ Each runtime requires the corresponding PHP extension.
 | Runtime | Requires | Application-side change |
 |---|---|---|
 | ext-parallel | ZTS PHP + ext-parallel | add `bin/async.php` |
-| ext-swoole | ext-swoole or ext-openswoole | install `AsyncSwooleModule`, use `bin/swoole.php` |
+| ext-swoole | ext-swoole or ext-openswoole | add a `swoole` context module, use `bin/swoole.php` |
 
 ## SQL resources with BDR + `#[Embed]`
 

--- a/manuals/1.0/ja/async.md
+++ b/manuals/1.0/ja/async.md
@@ -40,6 +40,14 @@ composer require bear/async
 | PHP-FPM / Apache（埋め込みリソースあり） | `bin/async.php` | ライブラリの`bootstrap.php`が`AppModule`に並列ランタイムを重ねる |
 | Swoole HTTPサーバー | `bin/swoole.php` | `AsyncSwooleModule`を`AppModule`にインストール |
 
+| | ext-parallel | ext-swoole |
+|---|---|---|
+| 並行の単位 | スレッドプール（CPUコア数） | コルーチン（数千） |
+| メモリ | ワーカーごとに独立 | プロセス内で共有 |
+| PDO | スレッドごとに独立 | 接続プールが要る |
+| サーバー | PHP-FPM / Apache | Swoole HTTPサーバー |
+| 導入 | `bin/async.php`を追加 | `bin/swoole.php`を追加 |
+
 ### 並列実行（ext-parallel）
 
 PHP-FPM / Apache上で動作する一般的なWebアプリケーション向けのランタイム環境です。ext-parallelのスレッドプールを使って`#[Embed]`を並列実行します。
@@ -80,11 +88,15 @@ exit((require $bootstrap)(
 exit((require $bootstrap)($context, 'MyVendor\MyApp', dirname(__DIR__), $GLOBALS, $_SERVER, 8));
 ```
 
+並列ランタイムを`AppModule`に直接インストールしないでください。bootstrap経由だけがサポートされる導入経路で、だからこそ同じ`AppModule`が`bin/app.php`（逐次）でも`bin/async.php`（並列）でも変更なしで動きます。
+
+PHP-FPM / Apacheでは`parallel\Runtime`のプールはプロセスの状態として持たれるため、プールを必要とするリクエストごとに作り直されます。スレッド生成、オートロード、DIコンテナ構築のコストはリクエストごとにかかります。`ParallelAsync`は最初のディスパッチ前にワーカーを1つ同期的に温めるので、コンテナ構築はスレッドごとではなく1回で済みますが、定常状態の低レイテンシにはプールをリクエスト間で保持する常駐プロセスが要ります。[`demo/bin/parallel-server.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/parallel-server.php)と[ベンチマーク結果](https://github.com/bearsunday/BEAR.Async/blob/1.x/docs/benchmark-results.md)を参照してください。
+
 #### ext-parallelの制約
 
 ワーカーは別スレッドで動作し、それぞれ独立したZendメモリ空間を持ちます。並列実行する埋め込みリソースは、順序に依存しない読み取り専用（冪等なGET）リソースにしてください。各ワーカーは独自のDIコンテナを持つため、リクエストローカルな可変状態や「同一インスタンスである」という前提はスレッド境界を越えて引き継がれません。
 
-スレッド境界をまたぐ引数と戻り値はコピー可能でなければなりません。具体的にはスカラー値・`null`・それらをネストした配列です。オブジェクトやクロージャ、リソースを渡した場合は即座にエラーになります。並列実行される埋め込みリソースに適用するインターセプターは冪等に保ち、リクエストローカルな共有状態を書き換えないでください。
+スレッド境界をまたぐ引数と戻り値はコピー可能でなければなりません。具体的にはスカラー値、`null`、それらをネストした配列です。オブジェクト、クロージャ、リソースを渡すと`NonCopyablePayloadException`で即座に失敗します。並列実行される埋め込みリソースに適用するインターセプターは冪等に保ち、リクエストローカルな共有状態を書き換えないでください。
 
 ### Swoole実行（ext-swoole）
 
@@ -95,18 +107,28 @@ ext-parallelはワーカー（別スレッド）で動作するため別エン�
 ```php
 use BEAR\Async\Module\AsyncSwooleModule;
 use BEAR\Async\Module\PdoPoolEnvModule;
+use BEAR\Package\PackageModule;
 
 class AppModule extends AbstractModule
 {
     protected function configure(): void
     {
         $this->install(new AsyncSwooleModule());
+        $this->install(new PackageModule());
         $this->install(new PdoPoolEnvModule('PDO_DSN', 'PDO_USER', 'PDO_PASSWORD'));
     }
 }
 ```
 
+`AsyncSwooleModule`は`PackageModule`より先にインストールします。Ray.Diは最初に登録された束縛を採用するので、順序が逆だとフレームワーク側の逐次実行の`LinkCrawler`と`EmbedInterceptor`が残り、`#[Embed]`は何も告げずに逐次実行になります。
+
+Swooleサーバーはコンパイル済みインジェクターで動かします。リフレクションで解決する`Injector`は解決中の状態をプロセス全体で共有しているため、provider内でコルーチンが待ちに入る（プールの接続待ちなど）と別のコルーチンが同じ状態に入り込み、循環していない連なりで`CircularDependency`が投げられます。`BEAR\Package\Injector`から起動して本番コンテキストではRay.Compilerの`CompiledInjector`を受け取り、サーバーがリクエストを受け付ける前に`warmup()`を呼んでコルーチンが1つしかないうちにsingletonを作り切ります。手順は[`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php)に、契約は[Ray.Di: コルーチンサーバー](https://ray-di.github.io/manuals/1.0/ja/performance_boost.html)にあります。
+
 Swooleではコルーチン同士がメモリを共有するため、`PdoPoolEnvModule`による接続プールが必要です。読み取り中心で埋め込みリソースを多用する構成では、外部から到達するHTTPリクエスト数だけでなく、1リクエスト内で同時に実行される埋め込みの数も加味してプールサイズを見積もります。キュー待ちを避けたい場合は `PDO_POOL_SIZE >= embed_count * request_concurrency` を目安にし、DBへの同時接続数を抑えたい場合はあえて小さめに設定します。
+
+`PdoPoolModule` / `RedisPoolModule`とそのenv版は`borrowTimeout`（既定5.0秒）を受け取ります。空きのないプールを待つと、いつまでもブロックする代わりに`PoolTimeoutException`で失敗します。貸し出しのたびにまず疎通を確認し（PDOは`SELECT 1`、Redisは`PING`）、死んだ接続は捨てて1回だけ取り直します。取り直した接続も死んでいれば、ドライバのエラーをpreviousに付けた`StalePooledConnectionException`が投げられます。Redis接続もPDOと同じくコルーチンごとにキャッシュされるので、同じコルーチン内で何度注入しても貸し出しは1回です。
+
+`ExtendedPdoInterface`、`PDO`、`Redis`をsingletonに注入しないでください。providerが渡すのは1つのコルーチンのために借りた接続で、singletonがそれを掴むとプロセスの寿命の間ずっと握り続け、プールが意味をなさずコルーチン間で接続が混ざります。DBを使う依存はprototypeスコープ（既定）のままにするか、`ProviderInterface<ExtendedPdoInterface>`を注入して使うたびに`get()`を呼びます。
 
 > **技術ノート（プール接続の取得方式）:** プールからの接続取得はコルーチン単位で管理されます。同じコルーチン内で`PDO`と`ExtendedPdo`の両方が注入された場合でも、両者は同一の接続を共有し、コルーチン終了時に`Coroutine::defer()`で一度だけプールへ返却されます。これにより、1つの処理が意図せず2本の接続を握ることを防ぎます。さらに`#[Embed]`で埋め込まれたリクエストは遅延評価されるため、埋め込みリソースを`#[Embed]`で宣言した時点ではプールから接続を確保せず、各リクエストが実際に実行される時点まで取得を遅らせます。
 >
@@ -136,13 +158,34 @@ class Dashboard extends ResourceObject
 
 ## なぜコード変更なしで動くのか
 
-BEAR.Sundayでは、情報がリソースとして URI で**構造化**されています。`#[Embed]`はそのリソースの実行結果ではなく、リソースリクエストそのものを埋め込み、リソース間の関係を宣言します。実行戦略 — 逐次・ext-parallelワーカー・Swooleコルーチン — を選ぶのは Linker の役割で、リソースクラスは自分が同期で呼ばれたか並列で呼ばれたかを知る必要がありません。
+BEAR.Sundayでは、情報がリソースとして URI で**構造化**されています。`#[Embed]`はそのリソースの実行結果ではなく、リソースリクエストそのものを埋め込み、リソース間の関係を宣言します。どの実行戦略（逐次、ext-parallelワーカー、Swooleコルーチン）を使うかを決めるのは Linker で、リソースクラスは自分が同期で呼ばれたか並列で呼ばれたかを知る必要がありません。
 
 通常モードではレンダリング時にこれらのリクエストが1つずつ逐次解決されますが、並列実行モードでは、最初の埋め込みリクエストが解決される時点で残りの埋め込みリクエストもまとめて並列に実行されます。BEAR.Asyncの非同期リクエストはBEAR.Resourceの通常リクエストと同じ型として扱えるため、HALレンダラなど周辺の仕組みはこの差を意識せずシリアライズに統合できます。
 
-非同期プログラミングでしばしば言われる「関数の色」問題 — 非同期関数を呼ぶ関数は自身も非同期でなければならず、コード全体が非同期に汚染される問題 — も、リソースという境界がこれを遮断します。同期と並列でコードは同じ、変わるのは実行戦略だけです。
+非同期プログラミングには「関数の色」問題があります。非同期関数を呼ぶ関数は自身も非同期でなければならず、非同期がコード全体に広がっていくというものです。BEAR.Sundayではリソースが境界になるため、これが起きません。同期と並列でコードは同じで、変わるのは実行戦略だけです。
 
 これはBEAR.Async固有ではなく、BEAR.Sunday全体の性質です。MVCフレームワークが「どう実行するか」を手続きで書く箇所を、BEAR.Sundayはリソース間の関係を宣言として表します。宣言は実行戦略から独立しているため、戦略の差し替えはコードに影響しません。
+
+## 仕組み
+
+BEAR.Asyncはbear/resourceの束縛を2つ差し替えます。
+
+1. `LinkCrawlerInterface` → `AsyncLinkCrawler`: `#[Link(crawl:)]`のグラフを階層ごとに辿ります。各階層のリクエストをまとめ、URI+クエリのハッシュで重複を除き、一括で実行して、結果を要求元すべてに配ります。
+2. `EmbedInterceptorInterface` → `AsyncEmbedInterceptor`: 各`#[Embed]`を`DeferredRequest`の上の`AsyncRequest`で包んで`PendingRequests`に登録します。どれか1つが最初にレンダリングされた時点で、溜まっている埋め込み全部を1バッチで実行します。
+
+どちらも設定された`AsyncInterface`アダプター（`ParallelAsync`、`SwooleAsync`、ランタイムモジュール未導入時の既定である`SyncAsync`）にバッチを渡します。
+
+```text
+階層1: Users → 全ユーザーのリクエストを並列実行
+階層2: 各ユーザーのPosts → 全投稿のリクエストを並列実行
+階層3: 各投稿のComments → 全コメントのリクエストを並列実行
+```
+
+### 失敗時の挙動
+
+埋め込みやクロールのタスクが1つ失敗しても、Swooleワーカーは落ちず、兄弟タスクも中断されません。全タスクが完了してから最初の例外が呼び出し元に投げ直され、そのリクエストだけが500になります。`ParallelAsync`も同じ規則で、ディスパッチした全`Future`をjoinしてから最初の`Throwable`を投げ直します。
+
+黙って代替に落ちることはありません。必要な拡張がロードされていなければ、該当モジュールが`configure()`の時点で`ExtensionNotLoadedException`を投げます。`SyncAsync`への降格はしません。
 
 ## デモとベンチマーク
 
@@ -159,7 +202,7 @@ BEAR.AsyncリポジトリにはSync・ext-parallel・Swooleの動作を比較で
 
 ## SQLリソースの並列化（BDR + `#[Embed]`）
 
-1ページで複数のSQLを発行したい場合、SQLごとにResourceObjectを分け、上位リソースから`#[Embed]`で束ねます。AsyncLinkerが`#[Embed]`をランタイムに応じて並列実行するので、利用側はリソースを組み合わせるだけで並列化されます。
+1ページで複数のSQLを発行したい場合、SQLごとにResourceObjectを分け、上位リソースから`#[Embed]`で束ねます。`#[Embed]`はランタイムに応じて並列実行されるので、利用側はリソースを組み合わせるだけで並列化されます。
 
 Ray.MediaQueryの[BDRパターン](https://github.com/ray-di/Ray.MediaQuery/blob/1.x/BDR_PATTERN.md)（`#[DbQuery]`インターフェース + ファクトリ + 不変ドメインオブジェクト）と組み合わせると、SQLは`var/sql/*.sql`にまとまり、リソース側はドメインオブジェクトを扱うだけになります。
 
@@ -174,7 +217,7 @@ use BEAR\Resource\Annotation\Embed;
 use BEAR\Resource\ResourceObject;
 use Ray\MediaQuery\Annotation\DbQuery;
 
-// ドメインオブジェクト — 不変スナップショット
+// ドメインオブジェクト: 不変スナップショット
 final class UserAccount
 {
     public function __construct(
@@ -184,7 +227,7 @@ final class UserAccount
     }
 }
 
-// リポジトリ — SQLは var/sql/user.sql に置く
+// リポジトリ: SQLは var/sql/user.sql に置く
 // UserFactoryで行をUserAccountにハイドレートする（ファクトリの詳細はBDR_PATTERN.md参照）
 interface UserRepositoryInterface
 {
@@ -192,7 +235,7 @@ interface UserRepositoryInterface
     public function getUser(int $id): UserAccount;
 }
 
-// リソース — SQL 1つにつき1リソース
+// リソース: SQL 1つにつき1リソース
 class User extends ResourceObject
 {
     public function __construct(private UserRepositoryInterface $repo)
@@ -207,7 +250,7 @@ class User extends ResourceObject
     }
 }
 
-// 集約リソース — `#[Embed]` がAsyncLinkerで自動的に並列化される
+// 集約リソース: `#[Embed]` がBEAR.Asyncで自動的に並列化される
 class UserDashboard extends ResourceObject
 {
     #[Embed(rel: 'user',     src: 'app://self/user{?id}')]
@@ -222,7 +265,7 @@ class UserDashboard extends ResourceObject
 
 - SQLは`var/sql/*.sql`に置く（Ray.MediaQueryの規約）
 - ドメインオブジェクトは不変スナップショット。呼び出し側で `$results['user'][0] ?? null` のような配列のお作法は不要
-- AsyncLinkerが3つのEmbedをext-parallel（PHP-FPM / Apache）またはSwooleコルーチンで並列実行
+- BEAR.Asyncが3つのEmbedをext-parallel（PHP-FPM / Apache）またはSwooleコルーチンで並列実行
 - ext-parallel/Swooleなしでも、同じコードがリクエストごとに同期実行される（PHP-FPMはリクエスト＝プロセスなので機能としては問題なし）
 - Swooleで動かす場合は`PdoPoolEnvModule`をインストールし、各コルーチンがプールからPDO接続を借りるようにする
 

--- a/manuals/1.0/ja/async.md
+++ b/manuals/1.0/ja/async.md
@@ -38,7 +38,7 @@ composer require bear/async
 | 用途 | エントリポイント | ランタイム設定 |
 |-----|-----|-----|
 | PHP-FPM / Apache（埋め込みリソースあり） | `bin/async.php` | ライブラリの`bootstrap.php`が`AppModule`に並列ランタイムを重ねる |
-| Swoole HTTPサーバー | `bin/swoole.php` | `AsyncSwooleModule`を`AppModule`にインストール |
+| Swoole HTTPサーバー | `bin/swoole.php` | `swoole`コンテキストモジュールが`AsyncSwooleModule`をインストールする。`AppModule`は変えない |
 
 | | ext-parallel | ext-swoole / ext-openswoole |
 |---|---|---|
@@ -102,25 +102,26 @@ PHP-FPM / Apacheでは`parallel\Runtime`のプールはプロセスの状態と�
 
 すでにSwoole HTTPサーバー上で稼働しており、高い並行性能を求めるアプリケーション向けのランタイム環境です。
 
-ext-parallelはワーカー（別スレッド）で動作するため別エントリポイントから選択しますが、ext-swooleは同一サーバープロセス内で動作するため、アプリケーションモジュールとしてインストールします。
+ext-parallelはワーカースレッドで動くので別エントリポイントで選びます。ext-swooleはサーバープロセスの中で動くので、コンテキスト文字列で選びます。`swoole`コンテキストモジュールを追加し、`prod-swoole-hal-api-app`のようなコンテキストで起動します。`AppModule`はそのままで、開発時は`bin/app.php`と`hal-api-app`で今までどおり逐次実行できます。
 
 ```php
+namespace MyVendor\MyApp\Module;
+
 use BEAR\Async\Module\AsyncSwooleModule;
 use BEAR\Async\Module\PdoPoolEnvModule;
-use BEAR\Package\PackageModule;
+use Ray\Di\AbstractModule;
 
-class AppModule extends AbstractModule
+final class SwooleModule extends AbstractModule
 {
     protected function configure(): void
     {
         $this->install(new AsyncSwooleModule());
-        $this->install(new PackageModule());
         $this->install(new PdoPoolEnvModule('PDO_DSN', 'PDO_USER', 'PDO_PASSWORD'));
     }
 }
 ```
 
-`AsyncSwooleModule`は`PackageModule`より先にインストールします。Ray.Diは最初に登録された束縛を採用するので、順序が逆だとフレームワーク側の逐次実行の`LinkCrawler`と`EmbedInterceptor`が残り、`#[Embed]`は何も告げずに逐次実行になります。
+コンテキストモジュールは`AppModule`を外側から包むので、その束縛はフレームワーク側の逐次実行の`LinkCrawler`と`EmbedInterceptor`より優先されます。代わりに`AsyncSwooleModule`を`AppModule`の中にインストールしないでください。Ray.Diは最初に登録された束縛を採用するため、`PackageModule`の後にインストールすると非同期の束縛は何も告げずに捨てられます。
 
 Swooleサーバーはコンパイル済みインジェクターで動かします。リフレクションで解決する`Injector`は解決中の状態をプロセス全体で共有しているため、provider内でコルーチンが待ちに入る（プールの接続待ちなど）と別のコルーチンが同じ状態に入り込み、循環していない連なりで`CircularDependency`が投げられます。`BEAR\Package\Injector`から起動して本番コンテキストではRay.Compilerの`CompiledInjector`を受け取り、サーバーがリクエストを受け付ける前に`warmup()`を呼んでコルーチンが1つしかないうちにsingletonを作り切ります。手順は[`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php)に、契約は[Ray.Di: コルーチンサーバー](https://ray-di.github.io/manuals/1.0/ja/performance_boost.html)にあります。
 
@@ -198,7 +199,7 @@ BEAR.AsyncリポジトリにはSync・ext-parallel・Swooleの動作を比較で
 | ランタイム環境 | 必要なもの | アプリケーション側の変更 |
 |-----|-----|-----|
 | ext-parallel | ZTS PHP + ext-parallel | `bin/async.php`を追加 |
-| ext-swoole | ext-swoole または ext-openswoole | `AsyncSwooleModule`をインストール、`bin/swoole.php`を使用 |
+| ext-swoole | ext-swoole または ext-openswoole | `swoole`コンテキストモジュールを追加、`bin/swoole.php`を使用 |
 
 ## SQLリソースの並列化（BDR + `#[Embed]`）
 

--- a/manuals/1.0/ja/async.md
+++ b/manuals/1.0/ja/async.md
@@ -40,7 +40,7 @@ composer require bear/async
 | PHP-FPM / Apache（埋め込みリソースあり） | `bin/async.php` | ライブラリの`bootstrap.php`が`AppModule`に並列ランタイムを重ねる |
 | Swoole HTTPサーバー | `bin/swoole.php` | `AsyncSwooleModule`を`AppModule`にインストール |
 
-| | ext-parallel | ext-swoole |
+| | ext-parallel | ext-swoole / ext-openswoole |
 |---|---|---|
 | 並行の単位 | スレッドプール（CPUコア数） | コルーチン（数千） |
 | メモリ | ワーカーごとに独立 | プロセス内で共有 |
@@ -124,7 +124,7 @@ class AppModule extends AbstractModule
 
 Swooleサーバーはコンパイル済みインジェクターで動かします。リフレクションで解決する`Injector`は解決中の状態をプロセス全体で共有しているため、provider内でコルーチンが待ちに入る（プールの接続待ちなど）と別のコルーチンが同じ状態に入り込み、循環していない連なりで`CircularDependency`が投げられます。`BEAR\Package\Injector`から起動して本番コンテキストではRay.Compilerの`CompiledInjector`を受け取り、サーバーがリクエストを受け付ける前に`warmup()`を呼んでコルーチンが1つしかないうちにsingletonを作り切ります。手順は[`demo/bin/swoole.php`](https://github.com/bearsunday/BEAR.Async/blob/1.x/demo/bin/swoole.php)に、契約は[Ray.Di: コルーチンサーバー](https://ray-di.github.io/manuals/1.0/ja/performance_boost.html)にあります。
 
-Swooleではコルーチン同士がメモリを共有するため、`PdoPoolEnvModule`による接続プールが必要です。読み取り中心で埋め込みリソースを多用する構成では、外部から到達するHTTPリクエスト数だけでなく、1リクエスト内で同時に実行される埋め込みの数も加味してプールサイズを見積もります。キュー待ちを避けたい場合は `PDO_POOL_SIZE >= embed_count * request_concurrency` を目安にし、DBへの同時接続数を抑えたい場合はあえて小さめに設定します。
+Swooleではコルーチン同士がメモリを共有するため、`PdoPoolEnvModule`による接続プールが必要です。読み取り中心で埋め込みリソースを多用する構成では、外部から到達するHTTPリクエスト数だけでなく、1リクエスト内で同時に実行される埋め込みの数も加味してプールサイズを見積もります。各コルーチンは終了まで接続を1本持ち、親リクエストも埋め込みの実行中は自分の接続を持ったままなので、`PDO_POOL_SIZE >= (1 + embed_count) * request_concurrency` を出発点にし、DBへの同時接続数を抑えたい場合はあえて小さめに設定します。
 
 `PdoPoolModule` / `RedisPoolModule`とそのenv版は`borrowTimeout`（既定5.0秒）を受け取ります。空きのないプールを待つと、いつまでもブロックする代わりに`PoolTimeoutException`で失敗します。貸し出しのたびにまず疎通を確認し（PDOは`SELECT 1`、Redisは`PING`）、死んだ接続は捨てて1回だけ取り直します。取り直した接続も死んでいれば、ドライバのエラーをpreviousに付けた`StalePooledConnectionException`が投げられます。Redis接続もPDOと同じくコルーチンごとにキャッシュされるので、同じコルーチン内で何度注入しても貸し出しは1回です。
 
@@ -198,7 +198,7 @@ BEAR.AsyncリポジトリにはSync・ext-parallel・Swooleの動作を比較で
 | ランタイム環境 | 必要なもの | アプリケーション側の変更 |
 |-----|-----|-----|
 | ext-parallel | ZTS PHP + ext-parallel | `bin/async.php`を追加 |
-| ext-swoole | ext-swoole | `AsyncSwooleModule`をインストール、`bin/swoole.php`を使用 |
+| ext-swoole | ext-swoole または ext-openswoole | `AsyncSwooleModule`をインストール、`bin/swoole.php`を使用 |
 
 ## SQLリソースの並列化（BDR + `#[Embed]`）
 


### PR DESCRIPTION
The BEAR.Async README and this page carried the same technical content and had drifted: the README had the install-order fix and the 0.4.0 pool hardening, this page still named the removed `AsyncLinker` and showed a Swoole `AppModule` without `PackageModule`.

This page becomes the single reference; the README will link here.

- Runtime comparison table, PHP-FPM pool-rebuild caveat, pool hardening (`borrowTimeout`, ping, `StalePooledConnectionException`), singleton-injection warning, "How it works", "Failure semantics"
- Swoole: install `AsyncSwooleModule` before `PackageModule`; boot on the compiled injector and `warmup()` before serving
- `AsyncLinker` references removed; en and ja carry the same facts in the same order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - BEAR.Asyncの英語・日本語マニュアルを更新しました。
  - ext-parallelとext-swooleの特徴、導入方法、実行時の違いを比較表で確認できるようになりました。
  - ワーカープールの再構築、ウォームアップ、接続プールのタイムアウトや接続状態に関する注意点を追加しました。
  - 内部の仕組みやバインディング、値の制約違反・接続取得失敗時の挙動を説明する節を追加しました。
  - 用語とコード例の表記を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->